### PR TITLE
Dashboard UX: navigation, progress polling, and simulation launch

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -65,6 +65,18 @@
 
 ---
 
+## 🚀 Performance (P1)
+
+Pipeline instrumentation and optimization. Persona generation and simulation analysis both take 1 minute+. These issues are ordered — #43 (instrumentation) should land first so the rest have data behind them.
+
+- [ ] **#43 — Instrument pipelines with wall-clock timing**: Add elapsed-time logging to every phase boundary in `GeneratePersonasUseCase` and `ParsePricingPageUseCase`. Log call counts, retry events, and batch vs. fallback paths. Output a summary timeline at the end of each pipeline run.
+- [ ] **#44 — Cache browser screenshots and HTML**: In-memory cache on VPS keyed by URL + viewport + locale. Skip Playwright navigation on repeat analyses. ~5-10s saved per cache hit.
+- [ ] **#45 — Merge persona generation phases incrementally**: Combine backstories + insights into one call (safe first step), then evaluate merging PB&J scaffolds (1 call per persona instead of 3). Do not merge all four phases at once — measure each change.
+- [ ] **#46 — Benchmark simulation concurrency**: Test p-limit values of 5, 7, 10, 12 for persona analysis. Plot the knee of the curve. Set to measured optimal, not guessed optimal.
+- [ ] **#47 — Reduce JSON parse failures and retries**: Measure batch backstory/insight parse failure rates. Add JSON repair before retry. Improve prompt-level JSON reliability.
+
+---
+
 ## 📋 TODO (Future Phases)
 
 ### Phase 3: Deep Evaluation & Refinement (P2)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -12,8 +12,8 @@ colors:
   secondary-foreground: oklch(0.95 0 0)
   muted: oklch(0.18 0.01 265)
   muted-foreground: oklch(0.52 0.01 265)
-  accent: oklch(0.62 0.2 230)
-  accent-foreground: oklch(0.98 0 0)
+  accent: oklch(0.18 0.01 265)
+  accent-foreground: oklch(0.95 0 0)
   destructive: oklch(0.58 0.2 28)
   border: oklch(0.2 0.01 265)
   input: oklch(0.2 0.01 265)
@@ -223,6 +223,15 @@ Flat by default. This system does not use box-shadows to convey surface hierarch
 - **Placeholder:** Muted Foreground at `oklch(0.40 0.01 265)`.
 - **Error:** Alert Red border. Error text in Alert Red at Label size.
 - **Disabled:** Full opacity at 0.4. No special background change.
+
+### Dropdown Menus
+
+- **Background:** Panel Surface with a subtle border (`1px border-border`), `6px` radius, shadow only on open (`shadow-md`).
+- **Item Hover:** Raised Surface background (`accent` / `oklch(0.22 0.008 265)` in dark mode). **Never Cerulean Blue** — the accent color is reserved for primary actions and data highlights, not hover feedback.
+- **Item Focus (keyboard):** Same as hover — tonal surface shift, not color.
+- **Item Text:** Foreground at rest, Muted Foreground for disabled/secondary text.
+- **Icons:** Muted Foreground, no color shift on hover.
+- **Separator:** Thin `1px` line using Panel Edge, inset with padding.
 
 ### Navigation / Sidebar
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,10 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Generated / vendor code:
+    ".netlify/**",
+    ".agents/**",
+    "test/**",
   ]),
 ]);
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,7 +15,6 @@ const eslintConfig = defineConfig([
     // Generated / vendor code:
     ".netlify/**",
     ".agents/**",
-    "test/**",
   ]),
 ]);
 

--- a/src/actions/generatePersonas.ts
+++ b/src/actions/generatePersonas.ts
@@ -18,7 +18,7 @@ const personasRateLimiter = new RateLimiterMemory({
 
 import { shouldRunLocally, VPS_BACKEND_URL, getVpsAuthToken } from "@/infrastructure/config";
 
-async function runLocally(personaDescription: string) {
+async function runLocally(personaDescription: string, count: number) {
     console.log("generatePersonasAction called...");
     const stream = createStreamableValue<any>({ step: "BRAINSTORMING_PERSONAS" });
 
@@ -44,7 +44,7 @@ async function runLocally(personaDescription: string) {
 
             const personas = await useCase.execute(personaDescription, (progress) => {
                 try { stream.update(progress); } catch {}
-            });
+            }, count);
 
             const finalPersonas = JSON.parse(JSON.stringify(personas));
             stream.done({ step: "DONE", personas: finalPersonas });
@@ -57,14 +57,14 @@ async function runLocally(personaDescription: string) {
     return { streamData: stream.value };
 }
 
-async function runRemote(personaDescription: string) {
+async function runRemote(personaDescription: string, count: number) {
     const res = await fetch(`${VPS_BACKEND_URL}/api/vps/generate-personas`, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${getVpsAuthToken()}`,
         },
-        body: JSON.stringify({ personaDescription }),
+        body: JSON.stringify({ personaDescription, count }),
     });
 
     if (!res.ok) {
@@ -76,7 +76,7 @@ async function runRemote(personaDescription: string) {
     return { streamData: undefined as unknown as ReturnType<typeof createStreamableValue>['value'], runId: data.runId as string };
 }
 
-export async function generatePersonasAction(personaDescription: string) {
-    if (shouldRunLocally()) return runLocally(personaDescription);
-    return runRemote(personaDescription);
+export async function generatePersonasAction(personaDescription: string, count: number = 5) {
+    if (shouldRunLocally()) return runLocally(personaDescription, count);
+    return runRemote(personaDescription, count);
 }

--- a/src/actions/generatePersonasFromInterviews.ts
+++ b/src/actions/generatePersonasFromInterviews.ts
@@ -40,10 +40,14 @@ async function runLocally(formData: FormData) {
     }
 
     const files: { filename: string; content: string }[] = [];
+    let personaCount = 5;
     for (const [key, value] of formData.entries()) {
         if (value instanceof File && (key === "files" || key.startsWith("file_"))) {
             const content = await value.text();
             files.push({ filename: value.name, content });
+        } else if (key === "count" && typeof value === "string") {
+            const parsed = parseInt(value, 10);
+            if (!isNaN(parsed) && parsed >= 1 && parsed <= 20) personaCount = parsed;
         }
     }
 
@@ -65,7 +69,7 @@ async function runLocally(formData: FormData) {
 
             const personas = await useCase.execute(files, (progress) => {
                 stream.update(progress);
-            });
+            }, personaCount);
 
             const finalPersonas = JSON.parse(JSON.stringify(personas));
             stream.done({ step: "DONE", personas: finalPersonas });

--- a/src/app/(app)/dashboard/simulations/page.tsx
+++ b/src/app/(app)/dashboard/simulations/page.tsx
@@ -1,11 +1,18 @@
 'use client'
 
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useSimulationStore } from '@/ui/stores/simulationStore'
+import { usePersonaStore } from '@/ui/stores/personaStore'
+import { useAnalysisFlow } from '@/ui/hooks/useAnalysisFlow'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { ClockIcon, GlobeIcon, UsersIcon, CheckCircleIcon, XCircleIcon, AlertCircleIcon, XIcon } from 'lucide-react'
+import { ClockIcon, GlobeIcon, UsersIcon, CheckCircleIcon, XCircleIcon, AlertCircleIcon, XIcon, PlusIcon } from 'lucide-react'
 import { computeRunAverages } from '@/ui/dashboard/utils/computeBenchmarks'
+import { Persona } from '@/domain/entities/Persona'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 
 function SimulationCard({ simulation }: { simulation: import('@/domain/entities/Simulation').Simulation }) {
   const router = useRouter()
@@ -130,22 +137,120 @@ function SimulationCard({ simulation }: { simulation: import('@/domain/entities/
   )
 }
 
+function NewSimulationForm({ onRun }: { onRun: (url: string, personas: Persona[]) => void }) {
+  const batches = usePersonaStore((s) => s.batches)
+  const [selectedBatchId, setSelectedBatchId] = useState<string>(batches[0]?.id ?? '')
+  const [url, setUrl] = useState('')
+
+  const selectedBatch = batches.find((b) => b.id === selectedBatchId)
+
+  const handleSubmit = () => {
+    if (!url.trim() || !selectedBatch) return
+    onRun(url, selectedBatch.personas)
+  }
+
+  if (batches.length === 0) {
+    return (
+      <Card>
+        <CardContent className="flex flex-col gap-3 text-sm text-muted-foreground">
+          <p>Create a persona batch first, then come back to run a simulation.</p>
+          <Button asChild variant="default" size="sm" className="w-fit">
+            <Link href="/dashboard">Go to Dashboard</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <label htmlFor="batch-select" className="text-sm font-medium">Persona Batch</label>
+          <Select value={selectedBatchId} onValueChange={setSelectedBatchId}>
+            <SelectTrigger id="batch-select">
+              <SelectValue placeholder="Select a batch" />
+            </SelectTrigger>
+            <SelectContent>
+              {batches.map((batch) => (
+                <SelectItem key={batch.id} value={batch.id}>
+                  {batch.label} — {batch.personas.length} personas
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-2">
+          <label htmlFor="pricing-url" className="text-sm font-medium">Pricing Page URL</label>
+          <Input
+            id="pricing-url"
+            type="url"
+            placeholder="https://your-startup.com/pricing"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+          />
+        </div>
+        <Button
+          disabled={!url.trim()}
+          onClick={handleSubmit}
+        >
+          Run Simulation
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}
+
 export default function SimulationsPage() {
   const simulations = useSimulationStore((s) => s.simulations)
+  const analysisFlow = useAnalysisFlow()
+  const [showNewForm, setShowNewForm] = useState(false)
 
   const inProgress = simulations.filter((s) => s.status === 'IN_PROGRESS')
   const completed = simulations.filter((s) => s.status !== 'IN_PROGRESS')
 
+  const handleRunSimulation = (url: string, personas: Persona[]) => {
+    analysisFlow.setPricingUrl(url)
+    analysisFlow.handleAnalyzePricing(personas)
+    setShowNewForm(false)
+  }
+
   return (
     <div className="flex flex-col gap-8 w-full h-full animate-in fade-in duration-500">
-      <div className="flex flex-col gap-2">
-        <h1 className="text-2xl font-bold tracking-tight">Simulations</h1>
-        <p className="text-sm text-muted-foreground">
-          {simulations.length === 0
-            ? 'No simulations yet. Run a pricing simulation from the dashboard to get started.'
-            : `${completed.length} completed · ${inProgress.length} in progress`}
-        </p>
+      <div className="flex items-start justify-between">
+        <div className="flex flex-col gap-2">
+          <h1 className="text-2xl font-bold tracking-tight">Simulations</h1>
+          <p className="text-sm text-muted-foreground">
+            {simulations.length === 0
+              ? 'No simulations yet. Run your first simulation to get started.'
+              : `${completed.length} completed · ${inProgress.length} in progress`}
+          </p>
+        </div>
+        <Button
+          onClick={() => setShowNewForm(!showNewForm)}
+          size="sm"
+        >
+          <PlusIcon className="h-3.5 w-3.5" />
+          Run New Simulation
+        </Button>
       </div>
+
+      {showNewForm && (
+        <NewSimulationForm onRun={handleRunSimulation} />
+      )}
+
+      {analysisFlow.isPending && (
+        <div className="rounded-lg border border-blue-500/20 bg-blue-500/5 p-4 text-sm text-blue-600 flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-blue-500 animate-pulse" />
+          Simulation is running…
+          <Link
+            href="/dashboard/simulations"
+            className="ml-auto text-xs font-medium text-blue-600 hover:underline"
+          >
+            Refresh
+          </Link>
+        </div>
+      )}
 
       {inProgress.length > 0 && (
         <section className="flex flex-col gap-3">
@@ -174,20 +279,14 @@ export default function SimulationsPage() {
         </section>
       )}
 
-      {simulations.length === 0 && (
+      {simulations.length === 0 && !showNewForm && (
         <div className="flex flex-col items-center justify-center py-24 text-center">
           <div className="h-12 w-12 rounded-full bg-muted/30 flex items-center justify-center mb-4">
             <ClockIcon className="h-6 w-6 text-muted-foreground" />
           </div>
           <p className="text-muted-foreground text-sm max-w-sm">
-            Run a pricing simulation from the dashboard with your personas, and it will appear here.
+            No simulations yet. Click "Run New Simulation" above to get started.
           </p>
-          <Link
-            href="/dashboard"
-            className="mt-4 inline-flex h-10 items-center justify-center rounded-md bg-primary px-6 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
-          >
-            Go to Dashboard
-          </Link>
         </div>
       )}
     </div>

--- a/src/app/(app)/dashboard/simulations/page.tsx
+++ b/src/app/(app)/dashboard/simulations/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useSimulationStore } from '@/ui/stores/simulationStore'
 import { usePersonaStore } from '@/ui/stores/personaStore'
 import { useAnalysisFlow } from '@/ui/hooks/useAnalysisFlow'
@@ -139,8 +139,15 @@ function SimulationCard({ simulation }: { simulation: import('@/domain/entities/
 
 function NewSimulationForm({ onRun }: { onRun: (url: string, personas: Persona[]) => void }) {
   const batches = usePersonaStore((s) => s.batches)
-  const [selectedBatchId, setSelectedBatchId] = useState<string>(batches[0]?.id ?? '')
+  const [selectedBatchId, setSelectedBatchId] = useState<string>('')
   const [url, setUrl] = useState('')
+
+  // Sync selected batch when batches hydrate or change
+  useEffect(() => {
+    if (batches.length > 0 && !batches.find((b) => b.id === selectedBatchId)) {
+      setSelectedBatchId(batches[0].id) // eslint-disable-line react-hooks/set-state-in-effect
+    }
+  }, [batches, selectedBatchId])
 
   const selectedBatch = batches.find((b) => b.id === selectedBatchId)
 

--- a/src/app/api/vps/generate-personas-from-interviews/route.ts
+++ b/src/app/api/vps/generate-personas-from-interviews/route.ts
@@ -52,6 +52,7 @@ export async function POST(req: NextRequest) {
     // ── Parse multipart form data ───────────────────────────────────────────
     const formData = await req.formData();
     const files: { filename: string; content: string }[] = [];
+    let personaCount = 5;
 
     for (const [key, value] of formData.entries()) {
         if (
@@ -60,6 +61,9 @@ export async function POST(req: NextRequest) {
         ) {
             const content = await value.text();
             files.push({ filename: value.name, content });
+        } else if (key === "count" && typeof value === "string") {
+            const parsed = parseInt(value, 10);
+            if (!isNaN(parsed) && parsed >= 1 && parsed <= 20) personaCount = parsed;
         }
     }
 
@@ -76,7 +80,7 @@ export async function POST(req: NextRequest) {
     // ── Generate runId and kick off background processing ───────────────────
     const runId = `pi-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
 
-    runPipeline(runId, files).catch((err) => {
+    runPipeline(runId, files, personaCount).catch((err) => {
         console.error(`[generate-personas-from-interviews] Background pipeline failed for ${runId}:`, err);
     });
 
@@ -90,6 +94,7 @@ export async function POST(req: NextRequest) {
 async function runPipeline(
     runId: string,
     files: { filename: string; content: string }[],
+    count: number,
 ) {
     try {
         storeProgress(runId, { step: "PARSING_FILES" });
@@ -110,7 +115,7 @@ async function runPipeline(
                 completedAnalyses: progress.current ?? progress.total ?? undefined,
                 totalAnalyses: progress.total ?? undefined,
             });
-        });
+        }, count);
 
         const serialized = JSON.parse(JSON.stringify(personas));
         personaGenerationStore.save(runId, serialized);

--- a/src/app/api/vps/generate-personas/route.ts
+++ b/src/app/api/vps/generate-personas/route.ts
@@ -30,7 +30,7 @@ const personasRateLimiter = new RateLimiterMemory({
 // ─────────────────────────────────────────────────────────────────────────────
 
 export async function POST(req: NextRequest) {
-  const { personaDescription } = await req.json();
+  const { personaDescription, count } = await req.json();
 
   // ── Validate input ──────────────────────────────────────────────────────
   if (!personaDescription || typeof personaDescription !== "string" || personaDescription.trim().length === 0) {
@@ -39,6 +39,8 @@ export async function POST(req: NextRequest) {
       { status: 400 },
     );
   }
+
+  const personaCount = typeof count === "number" && count >= 1 && count <= 20 ? count : 5;
 
   // ── Rate limit ──────────────────────────────────────────────────────────
   const clientIP =
@@ -60,7 +62,7 @@ export async function POST(req: NextRequest) {
   // ── Generate runId and kick off background generation ───────────────────
   const runId = `pt-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
 
-  runGeneration(runId, personaDescription).catch((err) => {
+  runGeneration(runId, personaDescription, personaCount).catch((err) => {
     console.error(`[generate-personas] Background generation failed for ${runId}:`, err);
   });
 
@@ -71,7 +73,7 @@ export async function POST(req: NextRequest) {
 // Background generation runner
 // ─────────────────────────────────────────────────────────────────────────────
 
-async function runGeneration(runId: string, personaDescription: string) {
+async function runGeneration(runId: string, personaDescription: string, count: number) {
   try {
     storeProgress(runId, { step: "BRAINSTORMING_PERSONAS" });
 
@@ -84,7 +86,7 @@ async function runGeneration(runId: string, personaDescription: string) {
         completedAnalyses: progress.completedCount ?? progress.completedSubSteps ?? undefined,
         totalAnalyses: progress.totalCount ?? progress.totalSubSteps ?? undefined,
       });
-    });
+    }, count);
 
     const serialized = JSON.parse(JSON.stringify(personas));
     personaGenerationStore.save(runId, serialized);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -59,8 +59,8 @@
   --secondary-foreground: oklch(0.14 0.01 265);
   --muted: oklch(0.89 0.005 265);
   --muted-foreground: oklch(0.50 0.01 265);
-  --accent: var(--primary);
-  --accent-foreground: var(--primary-foreground);
+  --accent: oklch(0.89 0.005 265);
+  --accent-foreground: oklch(0.14 0.01 265);
   --destructive: oklch(0.58 0.2 28);
   --destructive-foreground: oklch(0.98 0 0);
   --border: oklch(0.80 0.01 265);
@@ -92,8 +92,8 @@
   --secondary-foreground: oklch(0.95 0 0);
   --muted: oklch(0.22 0.008 265);
   --muted-foreground: oklch(0.55 0.01 265);
-  --accent: var(--primary);
-  --accent-foreground: var(--primary-foreground);
+  --accent: oklch(0.22 0.008 265);
+  --accent-foreground: oklch(0.95 0 0);
   --destructive: oklch(0.58 0.2 28);
   --destructive-foreground: oklch(0.98 0 0);
   --border: oklch(0.25 0.008 265);

--- a/src/application/usecases/GeneratePersonasFromInterviewsUseCase.ts
+++ b/src/application/usecases/GeneratePersonasFromInterviewsUseCase.ts
@@ -85,6 +85,7 @@ export class GeneratePersonasFromInterviewsUseCase {
     async execute(
         transcripts: { filename: string; content: string }[],
         onProgress?: (progress: InterviewPipelineProgress) => void,
+        count: number = 5,
     ): Promise<Persona[]> {
         if (transcripts.length === 0) {
             throw new Error("At least one interview transcript is required");
@@ -128,7 +129,7 @@ export class GeneratePersonasFromInterviewsUseCase {
 
         // Phase 3: Sample — weighted draw with LLM-based coherence validation
         onProgress?.({ step: 'SAMPLING' });
-        const targetCount = Math.max(successfulExtractions.length * 2, 10);
+        const targetCount = count;
 
         const sampledSignals = await samplePersonas(
             distribution,

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,257 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,190 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import { Select as SelectPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/src/infrastructure/adapters/PersonaAdapter.ts
+++ b/src/infrastructure/adapters/PersonaAdapter.ts
@@ -14,7 +14,7 @@ export class PersonaAdapter {
    * - Values, fears, communication style, decision style: Wang et al. (2024b) — psychographic specification
    */
   async generateInitialPersonas(personaDescription: string, count?: number): Promise<Persona[]> {
-    const personaCount = count ?? 3;
+    const personaCount = count ?? 5;
     const system = `You are a persona generator creating realistic buyer personas for SaaS pricing evaluation.
 
 Generate a JSON array of ${personaCount} DISTINCT personas matching this TypeScript interface:
@@ -195,7 +195,7 @@ Return ONLY valid JSON without explanatory text or markdown code blocks.`;
    * Streaming version of generateInitialPersonas using Vercel AI SDK's streamObject.
    */
   async * generateInitialPersonasStream(personaDescription: string, count?: number): AsyncIterable<Partial<Persona>[]> {
-    const personaCount = count ?? 3;
+    const personaCount = count ?? 5;
     const system = `You are a persona generator creating realistic buyer personas for SaaS pricing evaluation.
 Generate a JSON array of ${personaCount} DISTINCT personas matching this TypeScript interface:
 interface Persona {

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -1,10 +1,14 @@
 /**
  * Shared configuration for execution environment.
  * Controls whether server actions run locally or delegate to the VPS.
+ *
+ * IMPORTANT: This is intentionally hardcoded to `false`.
+ * Local dev tests against the live VPS to ensure parity with production.
+ * Do NOT change this without understanding the full deployment model.
  */
-
 export function shouldRunLocally(): boolean {
     return false;
+    // The original logic, kept for reference:
     // return process.env.NODE_ENV === "development" || process.env.IS_VPS === "true";
 }
 

--- a/src/ui/dashboard/components/DashboardClient.tsx
+++ b/src/ui/dashboard/components/DashboardClient.tsx
@@ -44,7 +44,7 @@ export function DashboardClient() {
     if (personaFlow.personas && showSetup) {
       setShowSetup(false)
     }
-  }, [personaFlow.personas])
+  }, [personaFlow.personas, showSetup])
 
   const toastIdRef = useRef<string | number | null>(null)
 

--- a/src/ui/dashboard/components/DashboardClient.tsx
+++ b/src/ui/dashboard/components/DashboardClient.tsx
@@ -1,28 +1,36 @@
 'use client'
 
-import { useState, useRef, useCallback } from 'react'
+import { useState, useRef, useCallback, useEffect } from 'react'
 import { toast } from 'sonner'
 import { usePersonaStore } from '@/ui/stores/personaStore'
 import { usePersonaFlow } from '@/ui/hooks/usePersonaFlow'
-import { useAnalysisFlow } from '@/ui/hooks/useAnalysisFlow'
+
 import { SetupView } from './views/SetupView'
 import { MinimalCard } from '@/components/custom/MinimalCard'
 import { PersonaProfilePanel } from '@/components/custom/PersonaProfilePanel'
 import { PersonaSkeletonCard } from '@/components/custom/PersonaSkeletonCard'
 import { PersonaDetailSheet } from '@/components/custom/PersonaDetailSheet'
 import type { VariationFormData } from '@/components/custom/SimilarPersonaDialog'
-import { LayersIcon, SparklesIcon } from 'lucide-react'
+import { LayersIcon, SparklesIcon, PlayIcon, PlusIcon, ChevronDownIcon, FileTextIcon, PenIcon } from 'lucide-react'
 import Link from 'next/link'
 import { FlowDialog } from '@/components/custom/FlowDialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { Persona } from '@/domain/entities/Persona'
 import { readStreamableValue } from '@ai-sdk/rsc'
 import { generateSimilarPersonasAction } from '@/actions/generateSimilarPersonas'
+import { useSimulationStore } from '@/ui/stores/simulationStore'
 
 export function DashboardClient() {
   const [selectedPersonaId, setSelectedPersonaId] = useState<string | null>(null)
   const [isDetailSheetOpen, setIsDetailSheetOpen] = useState(false)
   const [sheetDefaultTab, setSheetDefaultTab] = useState<"profile" | "chat" | "variant">("profile")
   const [pendingPersonaIds, setPendingPersonaIds] = useState<Set<string>>(new Set())
+  const [showSetup, setShowSetup] = useState(false)
   const batches = usePersonaStore((s) => s.batches)
   const activeBatchId = usePersonaStore((s) => s.activeBatchId)
   const setActiveBatch = usePersonaStore((s) => s.setActiveBatch)
@@ -30,12 +38,24 @@ export function DashboardClient() {
   const updatePersona = usePersonaStore((s) => s.updatePersona)
   const removePersona = usePersonaStore((s) => s.removePersona)
   const personaFlow = usePersonaFlow()
-  const analysisFlow = useAnalysisFlow()
+
+  // Auto-exit setup view when generation completes
+  useEffect(() => {
+    if (personaFlow.personas && showSetup) {
+      setShowSetup(false)
+    }
+  }, [personaFlow.personas])
+
   const toastIdRef = useRef<string | number | null>(null)
 
   const activeBatch = activeBatchId
     ? batches.find((b) => b.id === activeBatchId)
     : null
+
+  const simulations = useSimulationStore((s) => s.simulations)
+  const batchSimulationCount = activeBatchId
+    ? simulations.filter((s) => s.batchId === activeBatchId).length
+    : 0
 
   const getPersona = (id: string) => activeBatch?.personas.find(p => p.id === id) ?? null
   const selectedPersona = selectedPersonaId ? getPersona(selectedPersonaId) : null
@@ -222,29 +242,40 @@ export function DashboardClient() {
     [insertPersonasAfter, updatePersona],
   )
 
-  const showSetupView = batches.length === 0
+  const showSetupView = batches.length === 0 || showSetup
 
   return (
     <>
       {/* Main content — setup view or batch view */}
       {showSetupView ? (
         <div className="animate-in fade-in duration-500">
-          <SetupView
-            personaFlow={personaFlow}
-            analysisFlow={analysisFlow}
-            hasPersonas={false}
-          />
+          <SetupView personaFlow={personaFlow} onBack={batches.length > 0 ? () => setShowSetup(false) : undefined} />
         </div>
       ) : (
         <div className="flex flex-col gap-8 animate-in fade-in duration-500">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold tracking-tight">Personas</h1>
-        <Link
-          href="/dashboard/interviews"
-          className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-5 text-xs font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
-        >
-          + New from Interviews
-        </Link>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md bg-primary px-4 text-xs font-semibold text-primary-foreground transition-colors hover:bg-primary/90">
+              <PlusIcon className="h-3.5 w-3.5" />
+              New Batch
+              <ChevronDownIcon className="h-3 w-3 opacity-60" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-52">
+            <DropdownMenuItem onClick={() => { setActiveBatch(null); setShowSetup(true) }}>
+              <PenIcon className="h-4 w-4 mr-2" />
+              From ICP description
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link href="/dashboard/interviews">
+                <FileTextIcon className="h-4 w-4 mr-2" />
+                From interviews
+              </Link>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
 
       {!activeBatch ? (
@@ -282,9 +313,20 @@ export function DashboardClient() {
         <div className="flex flex-col gap-6">
           <div className="flex items-center justify-between border-b border-border/40 pb-4">
             <div className="flex flex-col gap-1">
-              <h2 className="text-xl font-bold tracking-tight">
-                {activeBatch.label}
-              </h2>
+              <div className="flex items-center gap-3">
+                <h2 className="text-xl font-bold tracking-tight">
+                  {activeBatch.label}
+                </h2>
+                {batchSimulationCount > 0 && (
+                  <Link
+                    href="/dashboard/simulations"
+                    className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary transition-colors hover:bg-primary/20"
+                  >
+                    <PlayIcon className="h-3 w-3" />
+                    {batchSimulationCount} simulation{batchSimulationCount !== 1 ? 's' : ''}
+                  </Link>
+                )}
+              </div>
               <p className="text-sm text-muted-foreground">
                 {activeBatch.personas.length} personas ·{' '}
                 {activeBatch.source === 'interviews'
@@ -300,40 +342,6 @@ export function DashboardClient() {
               All Batches
             </button>
           </div>
-          {activeBatch.source === 'interviews' && (
-            <div className="border-t border-border/40 pt-8 mt-8">
-              <div className="flex flex-col gap-6">
-                <div className="flex flex-col gap-2">
-                  <h3 className="text-lg font-semibold tracking-tight">Run Report</h3>
-                  <p className="text-sm text-muted-foreground">
-                    Test how these interview-grounded personas react to your pricing page.
-                  </p>
-                </div>
-                <div className="flex flex-col sm:flex-row gap-4">
-                  <input
-                    type="url"
-                    className="flex h-12 w-full rounded-md border border-input bg-transparent px-4 py-2 text-base transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-                    placeholder="https://your-startup.com/pricing"
-                    value={analysisFlow.pricingUrl}
-                    onChange={(e) => analysisFlow.setPricingUrl(e.target.value)}
-                    disabled={analysisFlow.isPending}
-                  />
-                  <button
-                    type="button"
-                    disabled={!analysisFlow.pricingUrl.trim() || analysisFlow.isPending}
-                    onClick={() => analysisFlow.handleAnalyzePricing(activeBatch.personas)}
-                    className="inline-flex h-12 whitespace-nowrap items-center justify-center rounded-md bg-foreground px-8 text-sm font-semibold text-background transition-colors hover:bg-foreground/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
-                  >
-                    {analysisFlow.isPending ? 'Simulating...' : 'Run Pricing Simulation'}
-                  </button>
-                </div>
-                {analysisFlow.error && (
-                  <p className="text-sm text-destructive font-medium bg-destructive/10 p-3 rounded-md">{analysisFlow.error}</p>
-                )}
-              </div>
-            </div>
-          )}
-
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {activeBatch.personas.map((persona, idx) => {
               // Use combined key to prevent collisions from duplicate persona IDs

--- a/src/ui/dashboard/components/DashboardClient.tsx
+++ b/src/ui/dashboard/components/DashboardClient.tsx
@@ -390,7 +390,7 @@ export function DashboardClient() {
           steps={[
             { title: 'Analyzing Market', description: 'Mapping demographics and psychographics' },
             { title: 'Generating Personas', description: 'Creating detailed backstories and traits' },
-            { title: 'Rationalizing Behavior', description: 'Anchoring psychographics to personality (PB&J)' },
+            { title: 'Rationalizing Behavior', description: 'Anchoring psychographics to personality traits' },
             { title: 'Finalizing', description: 'Preparing avatars, insights, and profiles' },
           ]}
         >
@@ -400,7 +400,9 @@ export function DashboardClient() {
                 {personaFlow.personaProgress.step === 'BRAINSTORMING_PERSONAS' &&
                   'Identifying key demographic segments...'}
                 {personaFlow.personaProgress.step === 'GENERATING_BACKSTORIES' &&
-                  `Fleshing out backstories (${personaFlow.personaProgress.completedCount || 0}/${personaFlow.personaProgress.totalCount || 3})`}
+                  personaFlow.personaProgress.totalCount
+                    ? `Fleshing out backstories (${personaFlow.personaProgress.completedCount ?? 0}/${personaFlow.personaProgress.totalCount})`
+                    : 'Fleshing out backstories...'}
                 {personaFlow.personaProgress.step === 'ENHANCING_WITH_PBJ' &&
                   'Building psychological rationales...'}
               </p>

--- a/src/ui/dashboard/components/Sidebar.tsx
+++ b/src/ui/dashboard/components/Sidebar.tsx
@@ -2,8 +2,9 @@
 
 import { usePersonaStore } from '@/ui/stores/personaStore'
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { Button } from '@/components/ui/button'
 import { UserIcon, FileTextIcon, LayersIcon, PlayIcon } from 'lucide-react'
 
 export function Sidebar() {
@@ -11,10 +12,19 @@ export function Sidebar() {
   const activeBatchId = usePersonaStore((s) => s.activeBatchId)
   const setActiveBatch = usePersonaStore((s) => s.setActiveBatch)
   const pathname = usePathname()
+  const router = useRouter()
 
   const isInterviews = pathname === '/dashboard/interviews'
   const isSimulations = pathname.startsWith('/dashboard/simulations')
   const isSettings = pathname === '/dashboard/settings'
+  const isPersonas = !isInterviews && !isSettings && !isSimulations
+
+  const handlePersonasClick = () => {
+    if (pathname === '/dashboard') {
+      setActiveBatch(null)
+    }
+    router.push('/dashboard')
+  }
 
   return (
     <aside className="w-60 shrink-0 border-r border-border/40 bg-sidebar flex flex-col h-full">
@@ -25,17 +35,18 @@ export function Sidebar() {
 
       {/* Nav links */}
       <nav className="flex flex-col p-3 gap-1">
-        <Link
-          href="/dashboard"
-          className={`flex items-center gap-3 px-3 py-2.5 rounded-md text-sm font-medium transition-colors ${
-            !isInterviews && !isSettings && !isSimulations
-              ? 'bg-primary/10 text-primary'
+        <Button
+          variant="ghost"
+          onClick={handlePersonasClick}
+          className={`justify-start gap-3 px-3 py-2.5 h-auto text-sm font-medium ${
+            isPersonas
+              ? 'bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary'
               : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'
           }`}
         >
           <UserIcon className="h-4 w-4" />
           Personas
-        </Link>
+        </Button>
         <Link
           href="/dashboard/interviews"
           className={`flex items-center gap-3 px-3 py-2.5 rounded-md text-sm font-medium transition-colors ${
@@ -73,7 +84,10 @@ export function Sidebar() {
               {batches.map((batch) => (
                 <button
                   key={batch.id}
-                  onClick={() => setActiveBatch(batch.id)}
+                  onClick={() => {
+                    setActiveBatch(batch.id)
+                    if (pathname !== '/dashboard') router.push('/dashboard')
+                  }}
                   className={`flex items-center gap-3 px-3 py-2 rounded-md text-xs transition-colors text-left w-full ${
                     activeBatchId === batch.id
                       ? 'bg-primary/10 text-primary'

--- a/src/ui/dashboard/components/Sidebar.tsx
+++ b/src/ui/dashboard/components/Sidebar.tsx
@@ -16,8 +16,7 @@ export function Sidebar() {
 
   const isInterviews = pathname === '/dashboard/interviews'
   const isSimulations = pathname.startsWith('/dashboard/simulations')
-  const isSettings = pathname === '/dashboard/settings'
-  const isPersonas = !isInterviews && !isSettings && !isSimulations
+  const isPersonas = pathname === '/dashboard'
 
   const handlePersonasClick = () => {
     if (pathname === '/dashboard') {

--- a/src/ui/dashboard/components/__tests__/Sidebar.test.tsx
+++ b/src/ui/dashboard/components/__tests__/Sidebar.test.tsx
@@ -4,8 +4,10 @@ import React from "react";
 
 // Stable mocks at module level
 const mockUsePathname = vi.fn();
+const mockPush = vi.fn();
 vi.mock("next/navigation", () => ({
   usePathname: () => mockUsePathname(),
+  useRouter: () => ({ push: mockPush }),
 }));
 
 const mockSetActiveBatch = vi.fn();
@@ -21,8 +23,13 @@ vi.mock("@/components/ui/scroll-area", () => ({
   ),
 }));
 
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, className, ...props }: any) => (
+    <button onClick={onClick} className={className} {...props}>{children}</button>
+  ),
+}));
+
 vi.mock("lucide-react", () => ({
-  MessageSquareIcon: () => <svg data-testid="message-square-icon" />,
   UserIcon: () => <svg data-testid="user-icon" />,
   FileTextIcon: () => <svg data-testid="file-text-icon" />,
   PlayIcon: () => <svg data-testid="play-icon" />,
@@ -47,50 +54,59 @@ vi.mock("next/link", () => ({
 
 import { Sidebar } from "../Sidebar";
 
+function getPersonasButton(container: HTMLElement) {
+  // The Personas nav item is a <button> inside the <nav>
+  const buttons = container.querySelectorAll("nav button");
+  for (const btn of buttons) {
+    if (btn.textContent?.includes("Personas")) return btn;
+  }
+  throw new Error("Could not find Personas button");
+}
+
 describe("Sidebar", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("renders the Debates link with correct href", () => {
+  it("highlights Personas when on /dashboard", () => {
     mockUsePathname.mockReturnValue("/dashboard");
     const { container } = render(<Sidebar />);
 
-    const link = container.querySelector('a[href="/dashboard/debates"]');
+    const personasBtn = getPersonasButton(container);
+    expect(personasBtn.className).toContain("bg-primary/10");
+  });
+
+  it("does NOT highlight Personas when on /dashboard/interviews", () => {
+    mockUsePathname.mockReturnValue("/dashboard/interviews");
+    const { container } = render(<Sidebar />);
+
+    const personasBtn = getPersonasButton(container);
+    expect(personasBtn.className).not.toContain("bg-primary/10");
+  });
+
+  it("does NOT highlight Personas when on /dashboard/simulations", () => {
+    mockUsePathname.mockReturnValue("/dashboard/simulations");
+    const { container } = render(<Sidebar />);
+
+    const personasBtn = getPersonasButton(container);
+    expect(personasBtn.className).not.toContain("bg-primary/10");
+  });
+
+  it("highlights Interviews when on /dashboard/interviews", () => {
+    mockUsePathname.mockReturnValue("/dashboard/interviews");
+    const { container } = render(<Sidebar />);
+
+    const link = container.querySelector('a[href="/dashboard/interviews"]');
     expect(link).not.toBeNull();
-    expect(container.querySelector('[data-testid="message-square-icon"]')).not.toBeNull();
+    expect(link!.className).toContain("bg-primary/10");
   });
 
-  it("does NOT highlight the home link when on /dashboard/debates", () => {
-    mockUsePathname.mockReturnValue("/dashboard/debates");
+  it("highlights Simulations when on /dashboard/simulations", () => {
+    mockUsePathname.mockReturnValue("/dashboard/simulations");
     const { container } = render(<Sidebar />);
 
-    const homeLink = container.querySelector('a[href="/dashboard"]');
-    expect(homeLink).not.toBeNull();
-
-    const cls = homeLink!.getAttribute("class") ?? "";
-    expect(cls).not.toContain("bg-primary/10");
-  });
-
-  it("highlights the Debates link when on /dashboard/debates", () => {
-    mockUsePathname.mockReturnValue("/dashboard/debates");
-    const { container } = render(<Sidebar />);
-
-    const debatesLink = container.querySelector('a[href="/dashboard/debates"]');
-    expect(debatesLink).not.toBeNull();
-
-    const cls = debatesLink!.getAttribute("class") ?? "";
-    expect(cls).toContain("bg-primary/10");
-  });
-
-  it("highlights the home link when on /dashboard", () => {
-    mockUsePathname.mockReturnValue("/dashboard");
-    const { container } = render(<Sidebar />);
-
-    const homeLink = container.querySelector('a[href="/dashboard"]');
-    expect(homeLink).not.toBeNull();
-
-    const cls = homeLink!.getAttribute("class") ?? "";
-    expect(cls).toContain("bg-primary/10");
+    const link = container.querySelector('a[href="/dashboard/simulations"]');
+    expect(link).not.toBeNull();
+    expect(link!.className).toContain("bg-primary/10");
   });
 });

--- a/src/ui/dashboard/components/views/SetupView.tsx
+++ b/src/ui/dashboard/components/views/SetupView.tsx
@@ -1,50 +1,35 @@
 "use client"
 
 import { usePersonaFlow } from '@/ui/hooks/usePersonaFlow'
-import { useAnalysisFlow } from '@/ui/hooks/useAnalysisFlow'
 import { MinimalCard } from '@/components/custom/MinimalCard'
 import { MOCK_PERSONAS } from '@/domain/entities/MockPersonas'
-import { MOCK_ANALYSES } from '@/domain/entities/MockAnalyses'
-import { Persona } from '@/domain/entities/Persona'
 import Link from 'next/link'
-import { ExternalLinkIcon } from 'lucide-react'
+import { ArrowRightIcon } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
 
 interface SetupViewProps {
   personaFlow: ReturnType<typeof usePersonaFlow>
-  analysisFlow: ReturnType<typeof useAnalysisFlow>
-  hasPersonas: boolean
-  currentSimulationId?: string | null
-  onStartSimulation?: (personas: Persona[]) => void
+  onBack?: () => void
 }
 
-export function SetupView({ personaFlow, analysisFlow, hasPersonas, currentSimulationId, onStartSimulation }: SetupViewProps) {
-  const loadMockPersonas = () => {
-    personaFlow.setPersonas(MOCK_PERSONAS)
-  }
-
-  const loadMockAnalysis = () => {
-    personaFlow.setPersonas(MOCK_PERSONAS)
-    const mockAnalysesList = Object.values(MOCK_ANALYSES)
-    analysisFlow.setAnalyses(mockAnalysesList)
-  }
-
+export function SetupView({ personaFlow, onBack }: SetupViewProps) {
   return (
     <div className="flex flex-col gap-16 max-w-4xl mx-auto w-full">
-      <div className="flex justify-end gap-4">
-        <button
-          type="button"
-          onClick={loadMockPersonas}
-          className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-4 transition-colors"
+      <div className="flex justify-between">
+        {onBack && (
+          <Button variant="ghost" size="sm" onClick={onBack} className="text-muted-foreground hover:text-foreground">
+            ← Back to batches
+          </Button>
+        )}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => personaFlow.setPersonas(MOCK_PERSONAS)}
+          className="text-muted-foreground hover:text-foreground ml-auto"
         >
           Load Demo Personas
-        </button>
-        <button
-          type="button"
-          onClick={loadMockAnalysis}
-          className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-4 transition-colors"
-        >
-          Load Demo Analysis
-        </button>
+        </Button>
       </div>
       <div className="flex flex-col gap-4 text-center items-center">
         <h1 className="text-4xl md:text-5xl font-bold tracking-tight text-balance">
@@ -56,7 +41,6 @@ export function SetupView({ personaFlow, analysisFlow, hasPersonas, currentSimul
       </div>
 
       <div className="grid gap-12">
-        {/* Step 1: Customer Profile */}
         <section className="flex flex-col gap-6 relative">
           <div className="absolute -left-12 top-0 flex h-8 w-8 items-center justify-center rounded-full border-2 border-primary text-primary font-bold hidden md:flex">
             1
@@ -67,74 +51,30 @@ export function SetupView({ personaFlow, analysisFlow, hasPersonas, currentSimul
                 <h2 className="text-xl font-semibold tracking-tight">Audience Description</h2>
                 <p className="text-sm text-muted-foreground">Describe your ideal customer, their pain points, and demographics.</p>
               </div>
-              <textarea 
-                className="w-full min-h-[160px] resize-y rounded-md border border-input bg-transparent px-4 py-3 text-base placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
+              <Textarea
+                className="w-full min-h-[160px] resize-y"
                 placeholder="e.g. B2B SaaS Founders dealing with high churn rates, usually aged 30-45..."
                 value={personaFlow.customerProfile}
                 onChange={(e) => personaFlow.setCustomerProfile(e.target.value)}
-                disabled={personaFlow.isPending || hasPersonas}
+                disabled={personaFlow.isPending}
               />
-              <div className="flex justify-end">
-                <button
-                  type="button"
-                  disabled={!personaFlow.customerProfile.trim() || personaFlow.isPending || hasPersonas}
+              <div className="flex items-center justify-between">
+                <Button variant="link" asChild className="h-auto p-0 text-muted-foreground">
+                  <Link href="/dashboard/interviews" className="inline-flex items-center gap-1">
+                    Have interview transcripts? Generate from interviews
+                    <ArrowRightIcon className="h-3.5 w-3.5" />
+                  </Link>
+                </Button>
+                <Button
+                  size="lg"
+                  disabled={!personaFlow.customerProfile.trim() || personaFlow.isPending}
                   onClick={personaFlow.handleGeneratePersonas}
-                  className="inline-flex h-12 items-center justify-center rounded-md bg-primary px-8 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
                 >
-                  {personaFlow.isPending ? "Generating..." : hasPersonas ? "Personas Generated" : "Generate Personas"}
-                </button>
+                  {personaFlow.isPending ? "Generating..." : "Generate Personas"}
+                </Button>
               </div>
               {personaFlow.error && (
                 <p className="text-sm text-destructive font-medium bg-destructive/10 p-3 rounded-md">{personaFlow.error}</p>
-              )}
-            </div>
-          </MinimalCard>
-        </section>
-
-        {/* Step 2: URL / Image Upload */}
-        <section className={`flex flex-col gap-6 relative transition-opacity duration-500 ${!hasPersonas ? 'opacity-40 pointer-events-none' : 'opacity-100'}`}>
-          <div className="absolute -left-12 top-0 flex h-8 w-8 items-center justify-center rounded-full border-2 border-primary text-primary font-bold hidden md:flex">
-            2
-          </div>
-          <MinimalCard>
-            <div className="flex flex-col gap-6">
-              <div className="flex flex-col gap-2">
-                <h2 className="text-xl font-semibold tracking-tight">Test Environment</h2>
-                <p className="text-sm text-muted-foreground">Provide the URL of the pricing page or feature you want these personas to evaluate.</p>
-              </div>
-              <div className="flex flex-col sm:flex-row gap-4">
-                <input 
-                  type="url"
-                  className="flex h-12 w-full rounded-md border border-input bg-transparent px-4 py-2 text-base transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-                  placeholder="https://your-startup.com/pricing"
-                  value={analysisFlow.pricingUrl}
-                  onChange={(e) => analysisFlow.setPricingUrl(e.target.value)}
-                  disabled={analysisFlow.isPending || !hasPersonas}
-                />
-                <button
-                  type="button"
-                  disabled={(!analysisFlow.pricingUrl.trim() && !analysisFlow.pricingImageBase64) || analysisFlow.isPending || !hasPersonas}
-                  onClick={() => onStartSimulation?.(personaFlow.personas!)}
-                  className="inline-flex h-12 whitespace-nowrap items-center justify-center rounded-md bg-foreground px-8 text-sm font-semibold text-background transition-colors hover:bg-foreground/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
-                >
-                  {analysisFlow.isPending ? "Simulating..." : "Run Simulation"}
-                </button>
-              </div>
-              {currentSimulationId && (
-                <div className="flex items-center gap-2 text-sm text-muted-foreground bg-primary/5 border border-primary/10 rounded-md p-3">
-                  <span className="h-2 w-2 rounded-full bg-blue-500 animate-pulse" />
-                  <span>Simulation started</span>
-                  <Link
-                    href={`/dashboard/simulations/${currentSimulationId}`}
-                    className="ml-auto inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
-                  >
-                    View progress
-                    <ExternalLinkIcon className="h-3 w-3" />
-                  </Link>
-                </div>
-              )}
-              {analysisFlow.error && (
-                <p className="text-sm text-destructive font-medium bg-destructive/10 p-3 rounded-md">{analysisFlow.error}</p>
               )}
             </div>
           </MinimalCard>

--- a/src/ui/dashboard/components/views/SetupView.tsx
+++ b/src/ui/dashboard/components/views/SetupView.tsx
@@ -58,6 +58,22 @@ export function SetupView({ personaFlow, onBack }: SetupViewProps) {
                 onChange={(e) => personaFlow.setCustomerProfile(e.target.value)}
                 disabled={personaFlow.isPending}
               />
+              <div className="flex flex-col gap-2">
+                <label htmlFor="persona-count" className="text-sm font-medium">Number of personas</label>
+                <input
+                  id="persona-count"
+                  type="number"
+                  min={1}
+                  max={20}
+                  value={personaFlow.personaCount}
+                  onChange={(e) => {
+                    const v = parseInt(e.target.value, 10)
+                    if (!isNaN(v) && v >= 1 && v <= 20) personaFlow.setPersonaCount(v)
+                  }}
+                  disabled={personaFlow.isPending}
+                  className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 w-24"
+                />
+              </div>
               <div className="flex items-center justify-between">
                 <Button variant="link" asChild className="h-auto p-0 text-muted-foreground">
                   <Link href="/dashboard/interviews" className="inline-flex items-center gap-1">

--- a/src/ui/hooks/useInterviewPipeline.ts
+++ b/src/ui/hooks/useInterviewPipeline.ts
@@ -25,6 +25,7 @@ export interface InterviewFile {
 
 export function useInterviewPipeline(onSuccess?: (personas: Persona[]) => void) {
   const [files, setFiles] = useState<InterviewFile[]>([])
+  const [personaCount, setPersonaCount] = useState(5)
   const [personas, setPersonas] = useState<Persona[] | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [isPending, setIsPending] = useState(false)
@@ -158,6 +159,7 @@ export function useInterviewPipeline(onSuccess?: (personas: Persona[]) => void) 
           const blob = new Blob([file.content], { type: 'text/plain' })
           formData.append('files', blob, file.name)
         }
+        formData.append('count', String(personaCount))
 
         const result: any = await generatePersonasFromInterviewsAction(formData)
         const streamData = result.streamData
@@ -222,7 +224,7 @@ export function useInterviewPipeline(onSuccess?: (personas: Persona[]) => void) 
         }
       }
     })()
-  }, [files, onSuccess])
+  }, [files, personaCount, onSuccess])
 
   // Cleanup on unmount
   useEffect(() => {
@@ -236,6 +238,7 @@ export function useInterviewPipeline(onSuccess?: (personas: Persona[]) => void) 
 
   return {
     files, addFile, removeFile, clearFiles,
+    personaCount, setPersonaCount,
     personas, setPersonas,
     error, setError,
     isPending,

--- a/src/ui/hooks/usePersonaFlow.ts
+++ b/src/ui/hooks/usePersonaFlow.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { Persona } from '@/domain/entities/Persona'
 import { generatePersonasAction } from '@/actions/generatePersonas'
 import { getPersonaGenerationResultAction } from '@/actions/getPersonaGenerationResult'
+import { getProgressAction } from '@/actions/getProgress'
 import { usePersonaStore, type PersonaBatch } from '@/ui/stores/personaStore'
 import { readStreamableValue } from '@ai-sdk/rsc'
 
@@ -52,6 +53,24 @@ export function usePersonaFlow(onSuccess?: (personas: Persona[]) => void) {
 
     const controller = abortControllerRef.current
     let cancelled = false
+    let progressInterval: ReturnType<typeof setInterval> | null = null
+
+    // Progress polling (fires immediately, then every 2s)
+    const pollProgress = async () => {
+      if (controller?.signal.aborted || !mountedRef.current || cancelled) return
+      try {
+        const p = await getProgressAction(runId)
+        if (p.found && p.progress && mountedRef.current) {
+          setPersonaProgress({
+            step: (p.progress.step as PersonaProgressStep) || 'BRAINSTORMING_PERSONAS',
+            completedCount: p.progress.completedAnalyses,
+            totalCount: p.progress.totalAnalyses,
+          })
+        }
+      } catch { /* non-critical */ }
+    }
+    pollProgress()
+    progressInterval = setInterval(pollProgress, 2000)
 
     ;(async () => {
       for (let attempt = 0; attempt < 300; attempt++) {
@@ -63,6 +82,7 @@ export function usePersonaFlow(onSuccess?: (personas: Persona[]) => void) {
           if (!pollResult.found) continue
 
           cancelled = true
+          if (progressInterval) clearInterval(progressInterval)
 
           if (pollResult.error) {
             if (mountedRef.current) {
@@ -94,6 +114,7 @@ export function usePersonaFlow(onSuccess?: (personas: Persona[]) => void) {
       }
 
       // Exhausted 300 attempts (10 min)
+      if (progressInterval) clearInterval(progressInterval)
       if (mountedRef.current) {
         setError('Persona generation timed out. Please try again.')
         setPersonaProgress(null)
@@ -101,7 +122,10 @@ export function usePersonaFlow(onSuccess?: (personas: Persona[]) => void) {
       }
     })()
 
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+      if (progressInterval) clearInterval(progressInterval)
+    }
   }, [runId, customerProfile, onSuccess])
 
   // ── Generate handler ───────────────────────────────────────────────────

--- a/src/ui/hooks/usePersonaFlow.ts
+++ b/src/ui/hooks/usePersonaFlow.ts
@@ -113,12 +113,14 @@ export function usePersonaFlow(onSuccess?: (personas: Persona[]) => void) {
         } catch { /* retry */ }
       }
 
-      // Exhausted 300 attempts (10 min)
-      if (progressInterval) clearInterval(progressInterval)
-      if (mountedRef.current) {
-        setError('Persona generation timed out. Please try again.')
-        setPersonaProgress(null)
-        abortControllerRef.current = null
+      // Only set timeout error if we actually timed out (not cancelled)
+      if (!cancelled && !controller?.signal.aborted) {
+        if (progressInterval) clearInterval(progressInterval)
+        if (mountedRef.current) {
+          setError('Persona generation timed out. Please try again.')
+          setPersonaProgress(null)
+          abortControllerRef.current = null
+        }
       }
     })()
 

--- a/src/ui/hooks/usePersonaFlow.ts
+++ b/src/ui/hooks/usePersonaFlow.ts
@@ -21,6 +21,7 @@ export interface PersonaProgress {
 
 export function usePersonaFlow(onSuccess?: (personas: Persona[]) => void) {
   const [customerProfile, setCustomerProfile] = useState('')
+  const [personaCount, setPersonaCount] = useState(5)
   const [personas, setPersonas] = useState<Persona[] | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [isPending, setIsPending] = useState(false)
@@ -143,7 +144,7 @@ export function usePersonaFlow(onSuccess?: (personas: Persona[]) => void) {
 
     ;(async () => {
       try {
-        const result: any = await generatePersonasAction(customerProfile)
+        const result: any = await generatePersonasAction(customerProfile, personaCount)
         const streamData = result.streamData
         const id = result.runId as string | undefined
         setIsPending(false) // core action returned — release loading state
@@ -198,11 +199,13 @@ export function usePersonaFlow(onSuccess?: (personas: Persona[]) => void) {
         }
       }
     })()
-  }, [customerProfile, onSuccess])
+  }, [customerProfile, personaCount, onSuccess])
 
   return {
     customerProfile,
     setCustomerProfile,
+    personaCount,
+    setPersonaCount,
     personas,
     setPersonas,
     error,

--- a/src/ui/interviews/InterviewUploadClient.tsx
+++ b/src/ui/interviews/InterviewUploadClient.tsx
@@ -18,6 +18,8 @@ export function InterviewUploadClient() {
     error,
     isPending,
     progress,
+    personaCount,
+    setPersonaCount,
     handleSubmit,
     handleCancel,
   } = useInterviewPipeline()
@@ -247,6 +249,24 @@ export function InterviewUploadClient() {
                   Need at least 2 interview transcripts to generate personas. Upload one more to proceed.
                 </p>
               )}
+
+              <div className="flex flex-col gap-2">
+                <label className="text-sm font-medium text-muted-foreground">
+                  Number of Personas to Generate
+                </label>
+                <input
+                  type="number"
+                  min={1}
+                  max={20}
+                  value={personaCount}
+                  onChange={(e) => setPersonaCount(Math.max(1, Math.min(20, Number(e.target.value) || 1)))}
+                  disabled={isPending}
+                  className="h-10 w-24 rounded-md border border-border bg-background px-3 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                />
+                <p className="text-xs text-muted-foreground">
+                  1–20 personas. More personas = richer behavioral coverage but longer generation time.
+                </p>
+              </div>
 
               <div className="flex justify-end">
                 <button


### PR DESCRIPTION
## Summary

Six focused changes to the dashboard experience, split into logical commits:

1. **Accent color fix** — Changed from cerulean (`--primary`) to neutral tonal values so dropdown hovers and accent backgrounds don't compete with primary actions.

2. **Sidebar navigation** — Personas click now preserves your active batch when navigating back from Simulations/Interviews. Recent Batches clicks now actually navigate to the batch detail view.

3. **Dashboard + SetupView cleanup** — New Batch dropdown replaces the single "+ New from Interviews" link. SetupView gets a back button and uses shadcn components. Removed dead "Load Demo Analysis" button and the inline simulation form (moved to its own page).

4. **VPS progress polling** — `usePersonaFlow` now polls `getProgressAction` for step-by-step updates when running against the VPS. Previously only polled for the final result, so the dialog stayed stuck on step 1.

5. **Inline simulation launch** — Simulations page now has a "Run New Simulation" button with batch selector and URL input. No more hunting through the batch view to start a simulation.

6. **Housekeeping** — Documented `shouldRunLocally()` intent (stays `false` for VPS parity). Added generated dirs to eslint ignore.