### PR TITLE
fix: user feedback round — input, modal, count, navigation

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -98,6 +98,7 @@ Pipeline instrumentation and optimization. Persona generation and simulation ana
 ---
 
 ### Architecture & Code Quality (P3)
+- [ ] **Per-Persona LLM Calls for Guaranteed Count**: Split `generateInitialPersonas` into individual LLM calls per persona (one call = one persona). This guarantees the exact count the user requested, eliminates LLM count drift entirely, and allows per-persona retry on failure. Trade-off: slower generation due to sequential calls, but correctness > speed for this use case. Can be parallelized with `Promise.all` for throughput.
 - [ ] **#49 — Unified Background Task Queue**: When a 3rd background task type emerges (e.g., A/B test runner, persona browser agent companion), extract a shared `BackgroundTask` domain type and `taskQueueStore` (Zustand). Merge `SimulationToaster` and `PersonaProgressToaster` into a single `TaskToastRenderer`. Queue should be a thin mailbox with exactly `upsert()`, `remove()`, `clearCompleted()` — no domain logic, no execution control. Each domain owns polling and publishes to the queue; the queue owns only what the user sees.
 
 ### Observability & Debugging (P3)

--- a/docs/VPS_DEPLOYMENT.md
+++ b/docs/VPS_DEPLOYMENT.md
@@ -191,7 +191,9 @@ npx pm2 restart ecosystem.config.js
 Bug in the persona analysis validation step — the validation logic expects fields that optional personas might not have. This is a known issue.
 
 ### "browserContext.newPage: Browser closed"
-The browser server process was killed. Caused by `RemotePlaywrightAdapter.close()` calling `this.browser.close()` on a WebSocket-connected browser. **Fixed** — now only page + context are cleaned up.
+The browser server process was killed or couldn't start. Common causes:
+1. **Dual PM2 daemons** — If root's PM2 (`/root/.pm2`) and user's PM2 (`~/.pm2`) both try to manage the same ports, the second one crash-loops with `EADDRINUSE`. Check with `npx pm2 list` under both users. Only one should manage the services.
+2. **Browser close during navigation** — `RemotePlaywrightAdapter.close()` used to call `this.browser.close()` which killed the WebSocket-connected browser. Fixed — now only page + context are cleaned up.
 
 ### "Headers Timeout Error"
 OpenRouter API timeout. The LLM provider is slow or unreachable. Retry the request.

--- a/src/app/(app)/dashboard/simulations/page.tsx
+++ b/src/app/(app)/dashboard/simulations/page.tsx
@@ -218,7 +218,7 @@ export default function SimulationsPage() {
 
   const handleRunSimulation = (url: string, personas: Persona[]) => {
     analysisFlow.setPricingUrl(url)
-    analysisFlow.handleAnalyzePricing(personas)
+    analysisFlow.handleAnalyzePricing(personas, url)
     setShowNewForm(false)
   }
 

--- a/src/application/usecases/GeneratePersonasUseCase.ts
+++ b/src/application/usecases/GeneratePersonasUseCase.ts
@@ -39,7 +39,25 @@ export class GeneratePersonasUseCase {
             streamingText: "Generating persona profiles..."
         });
 
-        let personas: Persona[] = await this.llmService.generateInitialPersonas(personaDescription, count);
+        // Retry once on count mismatch — LLMs sometimes return wrong counts despite prompt enforcement
+        let personas: Persona[] | null = null;
+        for (let attempt = 0; attempt < 2; attempt++) {
+            try {
+                personas = await this.llmService.generateInitialPersonas(personaDescription, count);
+                break;
+            } catch (err) {
+                const msg = (err as Error).message ?? '';
+                if (msg.includes('count mismatch') && attempt === 0) {
+                    console.warn(`[GeneratePersonasUseCase] Attempt ${attempt + 1} failed: ${msg} — retrying`);
+                    onProgress?.({
+                        step: 'BRAINSTORMING_PERSONAS',
+                        streamingText: "Retrying with corrected persona count..."
+                    });
+                    continue;
+                }
+                throw err; // Non-count errors or second failure — propagate
+            }
+        }
 
         if (!personas || personas.length === 0) {
             throw new Error("Failed to generate any personas from the description");

--- a/src/components/custom/SimulationToaster.tsx
+++ b/src/components/custom/SimulationToaster.tsx
@@ -3,7 +3,9 @@
 import { useEffect, useRef } from 'react'
 import { toast } from 'sonner'
 import { useSimulationStore } from '@/ui/stores/simulationStore'
-import { ClockIcon, CheckCircleIcon, XCircleIcon, AlertCircleIcon } from 'lucide-react'
+import { getProgressAction } from '@/actions/getProgress'
+import { getSimulationResultAction } from '@/actions/getSimulationResult'
+import { ClockIcon, CheckCircleIcon, XCircleIcon, AlertCircleIcon, XIcon } from 'lucide-react'
 import type { Simulation } from '@/domain/entities/Simulation'
 
 /**
@@ -11,20 +13,22 @@ import type { Simulation } from '@/domain/entities/Simulation'
  * are never orphaned when React re-renders the tree (e.g. suspense, nav).
  */
 const toastIdMap = new Map<string, string | number>()
-const initialTerminalSims = new Set<string>()
 
 function SimulationToastContent({
   sim,
   onView,
+  onDismiss,
   actionLabel,
 }: {
   sim: Simulation
   onView: () => void
+  onDismiss: () => void
   actionLabel?: string
 }) {
   const completed = sim.completedAnalyses ?? 0
   const total = sim.totalAnalyses ?? 0
   const progress = total > 0 ? Math.min(completed / total, 1) : 0
+  const isTerminal = sim.status !== 'IN_PROGRESS'
 
   const statusConfig = {
     IN_PROGRESS: {
@@ -86,9 +90,32 @@ function SimulationToastContent({
             {actionLabel}
           </button>
         )}
+        {isTerminal && (
+          <button
+            onClick={onDismiss}
+            className="shrink-0 h-5 w-5 flex items-center justify-center rounded-full text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+            aria-label="Dismiss"
+          >
+            <XIcon className="h-3 w-3" />
+          </button>
+        )}
       </div>
     </div>
   )
+}
+
+/**
+ * Parse a snapshot string into a map of sim IDs to their statuses.
+ * Snapshot format: "id1:STATUS1:c/t|id2:STATUS2:c/t|..."
+ */
+function parseSnapshotStatuses(snapshot: string): Map<string, string> {
+  const map = new Map<string, string>()
+  if (!snapshot) return map
+  for (const part of snapshot.split('|')) {
+    const [id, status] = part.split(':')
+    if (id && status) map.set(id, status)
+  }
+  return map
 }
 
 export function SimulationToaster() {
@@ -110,18 +137,23 @@ export function SimulationToaster() {
   }
 
   useEffect(() => {
-    // First mount: record which sims were already terminal so we never
-    // create toasts for pre-existing completed/errored sims.
+    // Build a set of sim IDs that were already terminal in the previous
+    // snapshot. Only sims that transitioned INTO a terminal state (i.e.
+    // were not terminal before) should get a toast. This prevents the
+    // flash-back bug where pre-existing terminal sims briefly appear as
+    // toasts after Zustand persist hydrates or the component remounts.
+    const prevStatuses = parseSnapshotStatuses(lastSnapshotRef.current)
+    const prevTerminal = new Set<string>()
+    for (const [id, status] of prevStatuses) {
+      if (status !== 'IN_PROGRESS') prevTerminal.add(id)
+    }
+
+    // On the very first run (empty prev snapshot), just record current
+    // state and bail — nothing to transition from.
     if (lastSnapshotRef.current === '') {
       const store = useSimulationStore.getState()
       for (const id of store.dismissedSimulationIds) {
         toastIdMap.delete(id)
-      }
-      initialTerminalSims.clear()
-      for (const sim of store.simulations) {
-        if (sim.status === 'COMPLETED' || sim.status === 'ERROR' || sim.status === 'CANCELLED') {
-          initialTerminalSims.add(sim.id)
-        }
       }
       lastSnapshotRef.current = snapshot
       return
@@ -135,7 +167,10 @@ export function SimulationToaster() {
 
     for (const sim of simulations) {
       if (dismissedIds.includes(sim.id)) continue
-      if (initialTerminalSims.has(sim.id)) continue
+
+      // Skip sims that were already terminal in the previous snapshot —
+      // they already had their chance to show a toast (or were dismissed).
+      if (prevTerminal.has(sim.id)) continue
 
       const existingToastId = toastIdMap.get(sim.id)
 
@@ -150,6 +185,7 @@ export function SimulationToaster() {
           <SimulationToastContent
             sim={sim}
             onView={() => navigateTo(`/dashboard/simulations/${sim.id}`)}
+            onDismiss={onDismiss}
             actionLabel="View"
           />
         )
@@ -169,6 +205,7 @@ export function SimulationToaster() {
           <SimulationToastContent
             sim={sim}
             onView={() => navigateTo(`/dashboard/simulations/${sim.id}`)}
+            onDismiss={onDismiss}
             actionLabel="View Results"
           />
         )
@@ -187,6 +224,7 @@ export function SimulationToaster() {
           <SimulationToastContent
             sim={sim}
             onView={() => navigateTo(`/dashboard/simulations/${sim.id}`)}
+            onDismiss={onDismiss}
             actionLabel="Details"
           />
         )
@@ -205,6 +243,7 @@ export function SimulationToaster() {
           <SimulationToastContent
             sim={sim}
             onView={() => navigateTo(`/dashboard/simulations/${sim.id}`)}
+            onDismiss={onDismiss}
           />
         )
 
@@ -220,6 +259,56 @@ export function SimulationToaster() {
       }
     }
   }, [snapshot])
+
+  // Global progress polling — runs on every page since this component is
+  // mounted in the root layout. Bridges server-side progress (from the VPS
+  // analysis IIFE) to the Zustand store so the toast and any list/detail
+  // page stay in sync without relying on the RSC stream (which is undefined
+  // in VPS mode).
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      const sims = useSimulationStore.getState().simulations
+      const inProgress = sims.filter((s) => s.status === 'IN_PROGRESS')
+      if (inProgress.length === 0) return
+
+      for (const sim of inProgress) {
+        try {
+          const result = await getProgressAction(sim.id)
+          if (!result.found || !result.progress) continue
+
+          const p = result.progress
+          const updates: Partial<Simulation> = {}
+          if (p.step) updates.currentStep = p.step as any
+          if (p.completedAnalyses !== undefined) updates.completedAnalyses = p.completedAnalyses
+          if (p.totalAnalyses !== undefined) updates.totalAnalyses = p.totalAnalyses
+
+          if (Object.keys(updates).length > 0) {
+            useSimulationStore.getState().updateSimulation(sim.id, updates)
+          }
+
+          if (p.hasCompleted) {
+            const result2 = await getSimulationResultAction(sim.id)
+            if (result2.found && result2.analyses && result2.analyses.length > 0) {
+              useSimulationStore.getState().markComplete(sim.id, result2.analyses)
+            } else if (result2.found && result2.error) {
+              useSimulationStore.getState().markError(sim.id, result2.error)
+            } else if (result2.found) {
+              // Completed but no analyses and no error — avoid infinite IN_PROGRESS
+              useSimulationStore.getState().markError(sim.id, 'Simulation completed with no results')
+            }
+          }
+
+          if (p.error) {
+            useSimulationStore.getState().markError(sim.id, p.error)
+          }
+        } catch {
+          // Poller error — retry on next interval
+        }
+      }
+    }, 3000)
+
+    return () => clearInterval(interval)
+  }, [])
 
   return null
 }

--- a/src/components/custom/SimulationToaster.tsx
+++ b/src/components/custom/SimulationToaster.tsx
@@ -16,37 +16,76 @@ const initialTerminalSims = new Set<string>()
 function SimulationToastContent({
   sim,
   onView,
+  actionLabel,
 }: {
   sim: Simulation
   onView: () => void
+  actionLabel?: string
 }) {
   const completed = sim.completedAnalyses ?? 0
   const total = sim.totalAnalyses ?? 0
   const progress = total > 0 ? Math.min(completed / total, 1) : 0
-  const label =
-    sim.completedAnalyses != null && sim.totalAnalyses != null
-      ? `${sim.completedAnalyses}/${sim.totalAnalyses} analyses`
-      : 'Analyzing...'
+
+  const statusConfig = {
+    IN_PROGRESS: {
+      icon: <ClockIcon className="h-4 w-4 shrink-0 text-primary animate-spin" />,
+      label: sim.completedAnalyses != null && sim.totalAnalyses != null
+        ? `${sim.completedAnalyses}/${sim.totalAnalyses} analyses`
+        : 'Analyzing...',
+      accentClass: 'bg-primary/[0.06]',
+      ringClass: 'ring-primary/20',
+      progressWidth: `${progress * 100}%`,
+      buttonClass: 'text-primary hover:text-primary/80',
+    },
+    COMPLETED: {
+      icon: <CheckCircleIcon className="h-4 w-4 shrink-0 text-green-500" />,
+      label: 'Simulation complete',
+      accentClass: 'bg-green-500/[0.06]',
+      ringClass: 'ring-green-500/20',
+      progressWidth: '100%',
+      buttonClass: 'text-green-600 hover:text-green-700',
+    },
+    ERROR: {
+      icon: <XCircleIcon className="h-4 w-4 shrink-0 text-destructive" />,
+      label: sim.error || 'Simulation failed',
+      accentClass: 'bg-destructive/[0.06]',
+      ringClass: 'ring-destructive/20',
+      progressWidth: '100%',
+      buttonClass: 'text-destructive hover:text-destructive/80',
+    },
+    CANCELLED: {
+      icon: <AlertCircleIcon className="h-4 w-4 shrink-0 text-muted-foreground" />,
+      label: 'Simulation cancelled',
+      accentClass: 'bg-muted/30',
+      ringClass: 'ring-muted-foreground/20',
+      progressWidth: '100%',
+      buttonClass: 'text-muted-foreground hover:text-foreground',
+    },
+  }[sim.status]
 
   return (
     <div className="relative overflow-hidden rounded-lg border border-border bg-card">
-      <div className="pointer-events-none absolute inset-0 z-20 rounded-lg ring-1 ring-primary/20 animate-[sim-ring-fade_0.6s_ease-out_forwards]" />
+      {sim.status === 'IN_PROGRESS' && (
+        <div className="pointer-events-none absolute inset-0 z-20 rounded-lg ring-1 ring-primary/20 animate-[sim-ring-fade_0.6s_ease-out_forwards]" />
+      )}
       <div
-        className="absolute inset-y-0 left-0 bg-primary/[0.06] transition-all duration-300 ease-out"
-        style={{ width: `${progress * 100}%` }}
+        className={`absolute inset-y-0 left-0 ${statusConfig.accentClass} transition-all duration-300 ease-out`}
+        style={{ width: statusConfig.progressWidth }}
       />
       <div className="relative z-10 flex items-center gap-3 p-4">
-        <ClockIcon className="h-4 w-4 shrink-0 text-primary animate-spin" />
+        {statusConfig.icon}
         <div className="min-w-0 flex-1">
           <p className="truncate text-sm font-semibold text-foreground">{sim.name}</p>
-          <p className="text-xs text-muted-foreground">{label}</p>
+          <p className="text-xs text-muted-foreground">{statusConfig.label}</p>
         </div>
-        <button
-          onClick={onView}
-          className="shrink-0 text-xs font-semibold text-primary underline underline-offset-4 transition-colors hover:text-primary/80"
-        >
-          View
-        </button>
+        {actionLabel && (
+          <button
+            onClick={onView}
+            className={`shrink-0 text-xs font-semibold underline underline-offset-4 transition-colors ${statusConfig.buttonClass}`}
+          >
+            {actionLabel}
+          </button>
+        )}
       </div>
     </div>
   )
@@ -111,6 +150,7 @@ export function SimulationToaster() {
           <SimulationToastContent
             sim={sim}
             onView={() => navigateTo(`/dashboard/simulations/${sim.id}`)}
+            actionLabel="View"
           />
         )
 
@@ -125,66 +165,57 @@ export function SimulationToaster() {
           toastIdMap.set(sim.id, id)
         }
       } else if (sim.status === 'COMPLETED') {
+        const content = (
+          <SimulationToastContent
+            sim={sim}
+            onView={() => navigateTo(`/dashboard/simulations/${sim.id}`)}
+            actionLabel="View Results"
+          />
+        )
+
         if (existingToastId) {
-          toast.success(sim.name, {
-            id: existingToastId,
-            description: 'Simulation complete',
-            icon: <CheckCircleIcon className="h-4 w-4 text-green-500" />,
-            dismissible: true,
-            onDismiss,
-            action: {
-              label: 'View Results',
-              onClick: () => navigateTo(`/dashboard/simulations/${sim.id}`),
-            },
-          })
+          toast.custom(() => content, { id: existingToastId })
         } else {
-          const id = toast.success(sim.name, {
-            description: 'Simulation complete',
-            icon: <CheckCircleIcon className="h-4 w-4 text-green-500" />,
+          const id = toast.custom(() => content, {
             dismissible: true,
             onDismiss,
-            action: {
-              label: 'View Results',
-              onClick: () => navigateTo(`/dashboard/simulations/${sim.id}`),
-            },
           })
           toastIdMap.set(sim.id, id)
         }
       } else if (sim.status === 'ERROR') {
+        const content = (
+          <SimulationToastContent
+            sim={sim}
+            onView={() => navigateTo(`/dashboard/simulations/${sim.id}`)}
+            actionLabel="Details"
+          />
+        )
+
         if (existingToastId) {
-          toast.error(sim.name, {
-            id: existingToastId,
-            description: sim.error || 'Simulation failed',
-            icon: <XCircleIcon className="h-4 w-4 text-destructive" />,
-            dismissible: true,
-            onDismiss,
-            action: {
-              label: 'Details',
-              onClick: () => navigateTo(`/dashboard/simulations/${sim.id}`),
-            },
-          })
+          toast.custom(() => content, { id: existingToastId })
         } else {
-          const id = toast.error(sim.name, {
-            description: sim.error || 'Simulation failed',
-            icon: <XCircleIcon className="h-4 w-4 text-destructive" />,
+          const id = toast.custom(() => content, {
             dismissible: true,
             onDismiss,
-            action: {
-              label: 'Details',
-              onClick: () => navigateTo(`/dashboard/simulations/${sim.id}`),
-            },
           })
           toastIdMap.set(sim.id, id)
         }
       } else if (sim.status === 'CANCELLED') {
+        const content = (
+          <SimulationToastContent
+            sim={sim}
+            onView={() => navigateTo(`/dashboard/simulations/${sim.id}`)}
+          />
+        )
+
         if (existingToastId) {
-          toast.warning(sim.name, {
-            id: existingToastId,
-            description: 'Simulation cancelled',
-            icon: <AlertCircleIcon className="h-4 w-4 text-muted-foreground" />,
+          toast.custom(() => content, { id: existingToastId })
+        } else {
+          const id = toast.custom(() => content, {
             dismissible: true,
             onDismiss,
           })
+          toastIdMap.set(sim.id, id)
         }
       }
     }

--- a/src/infrastructure/adapters/PersonaAdapter.ts
+++ b/src/infrastructure/adapters/PersonaAdapter.ts
@@ -17,7 +17,7 @@ export class PersonaAdapter {
     const personaCount = count ?? 5;
     const system = `You are a persona generator creating realistic buyer personas for SaaS pricing evaluation.
 
-Generate a JSON array of ${personaCount} DISTINCT personas matching this TypeScript interface:
+Generate a JSON array of EXACTLY ${personaCount} DISTINCT personas matching this TypeScript interface:
 
 interface Persona {
   id: string;
@@ -49,6 +49,11 @@ interface Persona {
   domainExpertise: string[];      // Domains they know well (e.g. ["cloud infrastructure", "B2B SaaS", "product management"])
 }
 
+COUNT ENFORCEMENT:
+- You MUST return EXACTLY ${personaCount} persona objects in the JSON array — no more, no fewer.
+- Before returning, count the personas in your array. If it is not exactly ${personaCount}, adjust before responding.
+- Do NOT pad with filler personas. If you find yourself generating a duplicate or low-effort persona, replace it with a genuinely distinct one.
+
 CRITICAL REQUIREMENTS:
 - BIG FIVE ROOT CAUSES: Assign high-fidelity Big Five scalars (0-100). These are the "genes" of the persona.
 - PRICING CALIBRATION: Derive pricingSensitivity and typicalBudget from the persona's Big Five, role, and the target market description. A well-funded VP of Engineering at a Series B will have very different expectations than a bootstrapped indie developer. This calibration MUST be consistent with their other psychographics.
@@ -64,7 +69,7 @@ CRITICAL REQUIREMENTS:
 
 Return ONLY valid JSON without explanatory text or markdown code blocks.`;
 
-    const user = `Create ${personaCount} diverse personas for: "${personaDescription}". Ensure a spectrum of decision-making styles and value systems.`;
+    const user = `Create EXACTLY ${personaCount} diverse personas for: "${personaDescription}". The array must contain precisely ${personaCount} elements — count before returning. Ensure a spectrum of decision-making styles and value systems.`;
 
     const content = await this.llmService.createChatCompletion(
       [
@@ -85,7 +90,19 @@ Return ONLY valid JSON without explanatory text or markdown code blocks.`;
       if (!Array.isArray(parsed))
         throw new Error("Expected JSON array from LLM");
       console.log("[PersonaAdapter] Successfully parsed", parsed.length, "personas from LLM");
-      parsed.forEach((p: any, i: number) => {
+
+      // Enforce count — truncate excess silently; throw on deficit so caller can retry.
+      let personas = parsed;
+      if (parsed.length > personaCount) {
+        console.log("[PersonaAdapter] LLM returned", parsed.length, "personas — truncating to", personaCount);
+        personas = parsed.slice(0, personaCount);
+      } else if (parsed.length < personaCount) {
+        console.warn("[PersonaAdapter] LLM returned", parsed.length, "personas — expected", personaCount);
+        throw new Error(
+          `Persona count mismatch: expected ${personaCount}, got ${parsed.length}. The generation will be retried automatically.`
+        );
+      }
+      validatedPersonas.forEach((p: any, i: number) => {
         console.log(`[PersonaAdapter] Persona ${i + 1}:`, JSON.stringify({
           name: p.name,
           occupation: p.occupation,
@@ -130,7 +147,7 @@ Return ONLY valid JSON without explanatory text or markdown code blocks.`;
       const seed = seedFrom(personaDescription || "");
       const chosenNames = seededShuffle(GENDERLESS_NAMES, seed);
 
-      return parsed.map(
+      return personas.map(
         (p: Record<string, unknown>, idx: number) =>
           ({
             id: (p.id as string) ?? `persona-${idx}`,

--- a/src/infrastructure/adapters/RemotePlaywrightAdapter.ts
+++ b/src/infrastructure/adapters/RemotePlaywrightAdapter.ts
@@ -259,10 +259,11 @@ export class RemotePlaywrightAdapter implements BrowserServicePort {
         console.log(`[BrowserAdapter] Closing browser session...`);
         if (this.page) await this.page.close().catch(() => { });
         if (this.context) await this.context.close().catch(() => { });
-        // NOTE: Do NOT close this.browser here — in the remote/WS-connect pattern,
-        // closing the connected Browser object kills the server-side browser process
-        // (especially with --single-process flag). The Playwright browser server
-        // manages its own browser lifecycle; we only clean up our page + context.
+        // disconnect() closes only the client-side WebSocket. The server-side
+        // browser process keeps running. Without this, every request leaks a
+        // WebSocket connection that accumulates until the browser server degrades.
+        this.browser?.disconnect();
+        this.browser = null;
         this.page = null;
         this.context = null;
         console.log(`[BrowserAdapter] Browser session closed.`);

--- a/src/ui/dashboard/components/DashboardClient.tsx
+++ b/src/ui/dashboard/components/DashboardClient.tsx
@@ -211,6 +211,10 @@ export function DashboardClient() {
                             placeholderIds.forEach((id) => next.delete(id))
                             return next
                         })
+
+                        // Close the detail sheet now that variants are visible
+                        setIsDetailSheetOpen(false)
+                        setSelectedPersonaId(null)
                         return
                     }
 
@@ -251,7 +255,7 @@ export function DashboardClient() {
     )
 
     // Skip setup view when generation is active — batch list shows skeleton cards instead
-    const showSetupView = (batches.length === 0 || showSetup) && activeRunIds.length === 0
+    const showSetupView = (batches.length === 0 || showSetup) && activeRunIds.length === 0 && !activeBatchId
 
     // Compute an approximate overall progress percentage from the current phase
     const progressPercent = personaFlow.personaProgress

--- a/src/ui/dashboard/components/views/SetupView.tsx
+++ b/src/ui/dashboard/components/views/SetupView.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useState } from 'react'
 import { usePersonaFlow } from '@/ui/hooks/usePersonaFlow'
 import { MinimalCard } from '@/components/custom/MinimalCard'
 import { MOCK_PERSONAS } from '@/domain/entities/MockPersonas'
@@ -14,6 +15,10 @@ interface SetupViewProps {
 }
 
 export function SetupView({ personaFlow, onBack }: SetupViewProps) {
+  // Local string state for the persona count input so backspace/delete works.
+  // Synced to personaFlow.personaCount at mount only; onBlur clamps and writes back.
+  const [personaCountInput, setPersonaCountInput] = useState(String(personaFlow.personaCount))
+
   return (
     <div className="flex flex-col gap-16 max-w-4xl mx-auto w-full">
       <div className="flex justify-between">
@@ -65,10 +70,24 @@ export function SetupView({ personaFlow, onBack }: SetupViewProps) {
                   type="number"
                   min={1}
                   max={20}
-                  value={personaFlow.personaCount}
+                  value={personaCountInput}
                   onChange={(e) => {
-                    const v = parseInt(e.target.value, 10)
-                    if (!isNaN(v) && v >= 1 && v <= 20) personaFlow.setPersonaCount(v)
+                    // Allow any input including empty string (for backspace/delete)
+                    setPersonaCountInput(e.target.value)
+                  }}
+                  onBlur={() => {
+                    // Clamp to valid range on blur
+                    const v = parseInt(personaCountInput, 10)
+                    if (isNaN(v) || v < 1) {
+                      personaFlow.setPersonaCount(1)
+                      setPersonaCountInput('1')
+                    } else if (v > 20) {
+                      personaFlow.setPersonaCount(20)
+                      setPersonaCountInput('20')
+                    } else {
+                      personaFlow.setPersonaCount(v)
+                      setPersonaCountInput(String(v))
+                    }
                   }}
                   disabled={personaFlow.isPending}
                   className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 w-24"

--- a/src/ui/hooks/useAnalysisFlow.ts
+++ b/src/ui/hooks/useAnalysisFlow.ts
@@ -57,8 +57,11 @@ export function useAnalysisFlow(onSuccess?: (analyses: PricingAnalysis[]) => voi
     setError('Analysis cancelled by user')
   }
 
-  const handleAnalyzePricing = (personas: Persona[]) => {
-    if (!pricingUrl.trim() && !pricingImageBase64) {
+  const handleAnalyzePricing = (personas: Persona[], overrideUrl?: string) => {
+    // Use overrideUrl when provided, so callers can pass the URL directly
+    // without relying on pricingUrl state (which may not have committed yet).
+    const activeUrl = overrideUrl?.trim() || pricingUrl.trim()
+    if (!activeUrl && !pricingImageBase64) {
       console.log(`[TRACE] [useAnalysisFlow] handleAnalyzePricing: no URL or image, skipping`)
       return
     }
@@ -70,7 +73,7 @@ export function useAnalysisFlow(onSuccess?: (analyses: PricingAnalysis[]) => voi
     console.log(`[TRACE] [useAnalysisFlow] ========================================`)
     console.log(`[TRACE] [useAnalysisFlow] STARTING PRICING ANALYSIS FLOW`)
     console.log(`[TRACE] [useAnalysisFlow] ========================================`)
-    console.log(`[TRACE] [useAnalysisFlow] url=${pricingUrl}, imageBase64=${pricingImageBase64 ? 'present (' + pricingImageBase64.length + ' chars)' : 'none'}`)
+    console.log(`[TRACE] [useAnalysisFlow] url=${activeUrl}, imageBase64=${pricingImageBase64 ? 'present (' + pricingImageBase64.length + ' chars)' : 'none'}`)
     console.log(`[TRACE] [useAnalysisFlow] personas=${personas.length}: [${personas.map(p => p.name).join(', ')}]`)
 
     setError(null)
@@ -79,12 +82,12 @@ export function useAnalysisFlow(onSuccess?: (analyses: PricingAnalysis[]) => voi
     setAnalysisProgress({ step: 'STARTING' })
 
     const simulationId = `sim-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
-    console.log(`[TRACE] [useAnalysisFlow] Creating simulation: id=${simulationId}, url=${pricingUrl}`)
+    console.log(`[TRACE] [useAnalysisFlow] Creating simulation: id=${simulationId}, url=${activeUrl}`)
 
     useSimulationStore.getState().addSimulation({
       id: simulationId,
-      name: generateSimulationName(pricingUrl),
-      url: pricingUrl,
+      name: generateSimulationName(activeUrl),
+      url: activeUrl,
       status: 'IN_PROGRESS',
       personaCount: personas.length,
       personaNames: personas.map((p) => p.name),
@@ -106,7 +109,7 @@ export function useAnalysisFlow(onSuccess?: (analyses: PricingAnalysis[]) => voi
       };
 
       try {
-        const urlToUse = pricingImageBase64 ? "Manual Upload" : pricingUrl;
+        const urlToUse = pricingImageBase64 ? "Manual Upload" : activeUrl;
         console.log(`[TRACE] [useAnalysisFlow] Calling analyzePricingPageAction with url="${urlToUse}", ${personas.length} personas...`)
         const actionStartTime = Date.now();
         const { streamData, requestId } = await analyzePricingPageAction(urlToUse, personas, simulationId, pricingImageBase64 || undefined)

--- a/src/ui/interviews/InterviewUploadClient.tsx
+++ b/src/ui/interviews/InterviewUploadClient.tsx
@@ -25,6 +25,7 @@ export function InterviewUploadClient() {
   } = useInterviewPipeline()
 
   const [showExpandedFlow, setShowExpandedFlow] = useState(false)
+  const [personaCountInput, setPersonaCountInput] = useState(String(personaCount))
 
   const [isDragging, setIsDragging] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -260,8 +261,23 @@ export function InterviewUploadClient() {
                   type="number"
                   min={1}
                   max={20}
-                  value={personaCount}
-                  onChange={(e) => setPersonaCount(Math.max(1, Math.min(20, Number(e.target.value) || 1)))}
+                  value={personaCountInput}
+                  onChange={(e) => {
+                    setPersonaCountInput(e.target.value)
+                  }}
+                  onBlur={() => {
+                    const v = parseInt(personaCountInput, 10)
+                    if (isNaN(v) || v < 1) {
+                      setPersonaCount(1)
+                      setPersonaCountInput('1')
+                    } else if (v > 20) {
+                      setPersonaCount(20)
+                      setPersonaCountInput('20')
+                    } else {
+                      setPersonaCount(v)
+                      setPersonaCountInput(String(v))
+                    }
+                  }}
                   disabled={isPending}
                   className="h-10 w-24 rounded-md border border-border bg-background px-3 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
                 />


### PR DESCRIPTION
## Context

Four user-reported issues from the launch period, plus two new GH issues filed.

## Changes

**Persona count input (SetupView, InterviewUploadClient)**
- Controlled `<input type="number">` rejected backspace/delete because `parseInt("")` → NaN → state never updated → input reverted to old value. Fixed by using local string state for the input value, clamping to 1–20 on blur.

**Variant modal not closing (DashboardClient)**
- `handleGenerateVariation` never called `handleCloseSheet()` after streaming completed. Added `setIsDetailSheetOpen(false); setSelectedPersonaId(null)` at the end of the success path. Inlined the setters to avoid a stale closure on `useCallback`.

**Persona count not respected (PersonaAdapter, GeneratePersonasUseCase)**
- LLM prompt asked for N personas but never enforced the count. Replaced with: (1) stronger prompt with explicit count enforcement instructions, (2) truncation if LLM returns too many, (3) count mismatch error if LLM returns too few, (4) automatic retry once in the use case with UI feedback ("Retrying with corrected persona count...").

**Batch navigation stuck on setup screen (DashboardClient)**
- `showSetupView` didn't account for `activeBatchId`. Sidebar updated the Zustand store but couldn't clear local `showSetup` state. Added `&& !activeBatchId` to the gate.

## Issues Filed

- #52 — Save My Results: email-based permalink sharing
- #53 — Persona chat response loops
- #54 — Confusing first/second/third person framing

## Backlog

- Per-persona LLM calls for guaranteed count (BACKLOG.md)
