### PR TITLE
fix: prevent stuck simulations and support concurrent browser sessions

### DIFF
--- a/playwright-server.js
+++ b/playwright-server.js
@@ -1,0 +1,40 @@
+const { chromium } = require("playwright-core");
+const port = parseInt(process.env.PLAYWRIGHT_PORT || "8081", 10);
+const wsPath = process.env.PLAYWRIGHT_WS_PATH || "playwright-ws";
+
+async function main() {
+    console.log("[PlaywrightServer] Launching browser server on port " + port + "...");
+    const browserServer = await chromium.launchServer({
+        port,
+        wsPath,
+        headless: true,
+        args: [
+            "--no-sandbox",
+            "--disable-setuid-sandbox",
+            "--disable-dev-shm-usage",
+            "--disable-gpu",
+        ]
+    });
+
+    const wsEndpoint = browserServer.wsEndpoint();
+    console.log("[PlaywrightServer] Browser server ready!");
+    console.log("[PlaywrightServer] WebSocket endpoint: " + wsEndpoint);
+    console.log("[PlaywrightServer] Connect via: ws://localhost:" + port + "/" + wsPath);
+
+    process.on("SIGINT", async () => {
+        console.log("[PlaywrightServer] Shutting down...");
+        await browserServer.close();
+        process.exit(0);
+    });
+
+    process.on("SIGTERM", async () => {
+        console.log("[PlaywrightServer] Shutting down...");
+        await browserServer.close();
+        process.exit(0);
+    });
+}
+
+main().catch(function(err) {
+    console.error("[PlaywrightServer] Failed to start:", err.message);
+    process.exit(1);
+});

--- a/src/app/api/vps/analyze-pricing/route.ts
+++ b/src/app/api/vps/analyze-pricing/route.ts
@@ -92,8 +92,17 @@ export async function POST(req: NextRequest) {
     }
 
     // ── Kick off background analysis ────────────────────────────────────────
-    runAnalysis(id, url, personas, imageBase64).catch((err) => {
+    const ANALYSIS_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+
+    Promise.race([
+        runAnalysis(id, url, personas, imageBase64),
+        new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error('Analysis timed out after 10 minutes')), ANALYSIS_TIMEOUT_MS)
+        ),
+    ]).catch((err) => {
         console.error(`[analyze-pricing] Background analysis failed for ${id}:`, err);
+        simulationResultStore.saveError(id, err.message);
+        storeProgress(id, { step: 'ERROR', error: err.message });
     });
 
     return NextResponse.json({ runId: id });
@@ -111,20 +120,22 @@ async function runAnalysis(
 ) {
     const startTime = Date.now();
     const log = AnalysisLogger.forRun(id);
-    await log.init();
-
-    const abortController = cancellationManager.createRequest(id);
-    const abortSignal = abortController.signal;
-
-    log.info("runAnalysis", "=== ANALYSIS START ===", {
-        url,
-        personaCount: personas.length,
-        personaNames: personas.map((p) => p.name),
-        hasImage: !!imageBase64,
-        requestId: id,
-    });
+    let abortSignal: AbortSignal = new AbortController().signal;
 
     try {
+        await log.init();
+
+        const abortController = cancellationManager.createRequest(id);
+        abortSignal = abortController.signal;
+
+        log.info("runAnalysis", "=== ANALYSIS START ===", {
+            url,
+            personaCount: personas.length,
+            personaNames: personas.map((p) => p.name),
+            hasImage: !!imageBase64,
+            requestId: id,
+        });
+
         if (abortSignal.aborted) {
             log.warn("runAnalysis", "Request was already aborted before starting");
             simulationResultStore.saveError(id, "Request was cancelled");

--- a/src/ui/hooks/useAnalysisFlow.ts
+++ b/src/ui/hooks/useAnalysisFlow.ts
@@ -5,6 +5,7 @@ import { analyzePricingPageAction } from '@/actions/analyzePricingPage'
 import { predictGazeAction } from '@/actions/predictGaze'
 import { cancelRequestAction } from '@/actions/cancelRequest'
 import { getSimulationResultAction } from '@/actions/getSimulationResult'
+import { getProgressAction } from '@/actions/getProgress'
 import { getScreenshotAction } from '@/actions/getScreenshot'
 import { readStreamableValue } from '@ai-sdk/rsc'
 import { PricingAnalysisProgressStep } from '@/application/usecases/ParsePricingPageUseCase'
@@ -209,9 +210,24 @@ export function useAnalysisFlow(onSuccess?: (analyses: PricingAnalysis[]) => voi
 
         // ── Remote/VPS or stream-disconnected: poll result store ────────────
         console.log(`[TRACE] [useAnalysisFlow] Polling result store. simulationId=${simulationId}, requestId=${requestId}`)
-        for (let attempt = 0; attempt < 300; attempt++) {
+        for (let attempt = 0; attempt < 600; attempt++) {
           if (!mountedRef.current || controller.signal.aborted) break
           await new Promise((r) => setTimeout(r, 1000))
+
+          // Poll progress every 3 seconds for step/completedCount visibility
+          if (attempt % 3 === 0) {
+            try {
+              const progressResult = await getProgressAction(simulationId)
+              if (progressResult.found && progressResult.progress) {
+                const p = progressResult.progress
+                useSimulationStore.getState().updateSimulation(simulationId, {
+                  currentStep: (p.step as any) ?? undefined,
+                  completedAnalyses: p.completedCount ?? p.completedAnalyses,
+                })
+              }
+            } catch { /* non-critical */ }
+          }
+
           try {
             const result = await getSimulationResultAction(simulationId)
             if (!result.found) continue
@@ -231,17 +247,18 @@ export function useAnalysisFlow(onSuccess?: (analyses: PricingAnalysis[]) => voi
           } catch { /* retry */ }
         }
 
-        // Exhausted 300 polling attempts (~5 min) without a result
+        // Exhausted 600 polling attempts (~10 min) without a result
         clearScreenshotPoll()
         if (mountedRef.current && !controller.signal.aborted) {
           setError('Simulation analysis timed out. Please try again.')
-          useSimulationStore.getState().markError(simulationId, 'Timed out after 300 polling attempts')
+          useSimulationStore.getState().markError(simulationId, 'Timed out after 600 polling attempts')
           setAnalysisProgress(null)
           setCurrentRequestId(null)
         }
       } catch (err) {
         clearScreenshotPoll()
         console.log(`[TRACE] [useAnalysisFlow] CAUGHT ERROR:`, (err as Error).message)
+        useSimulationStore.getState().markError(simulationId, (err as Error).message)
         if (mountedRef.current) {
           if (!controller.signal.aborted) {
             setError((err as Error).message)


### PR DESCRIPTION
## Context

Pricing simulations were stuck at '0 of 3 personas — Initialization' with no progress. Three separate issues combined to cause this:

1. The standalone build was missing `playwright-core/browsers.json`, so the entire pricing route module failed to load — every POST returned 500.
2. When the POST failed, `useAnalysisFlow` never called `markError()`, leaving simulations permanently stuck as IN_PROGRESS in the Zustand store.
3. The browser server launched Chrome with `--single-process`, which crashes when multiple WebSocket clients create contexts concurrently.

## Changes

**fix(simulation): prevent stuck IN_PROGRESS states and add VPS error handling**

- Add `markError()` to `useAnalysisFlow` catch block so failed analyses don't stay stuck
- Poll `getProgressAction` every 3rd attempt in VPS result loop for live step visibility
- Move `log.init()` and `cancellationManager.createRequest()` inside try/catch in runAnalysis
- Add 10-minute `Promise.race` timeout on runAnalysis + save error to stores on `.catch()`
- Increase client polling from 300 to 600 attempts to match VPS timeout

**fix(browser): remove --single-process for concurrent analysis support**

- Remove `--single-process` from Chrome args in playwright-server.js so Chrome spawns separate processes per context
- Add playwright-server.js to the repo so deploys include it

## Tradeoffs

The VPS deploy process needs `npm run build` (not `npx next build`) for the `postbuild` script to copy `browsers.json` to the standalone directory. This is already set up but was missed in the last deploy cycle.

Removing `--single-process` means Chrome uses more RAM per concurrent analysis (roughly 100-200MB per context). With 5GB available on the VPS, this supports ~5 concurrent analyses comfortably.