### PR TITLE
feat(interviews): allow single interview upload; remove minimum-2 constraint

### DIFF
--- a/src/application/usecases/GeneratePersonasFromInterviewsUseCase.ts
+++ b/src/application/usecases/GeneratePersonasFromInterviewsUseCase.ts
@@ -117,9 +117,9 @@ export class GeneratePersonasFromInterviewsUseCase {
             }
         }
 
-        if (successfulExtractions.length < 2) {
+        if (successfulExtractions.length === 0) {
             throw new Error(
-                `Only ${successfulExtractions.length} interview(s) extracted successfully. Need at least 2.`,
+                `No interviews extracted successfully. At least one is required.`,
             );
         }
 

--- a/src/application/usecases/__tests__/GeneratePersonasFromInterviewsUseCase.test.ts
+++ b/src/application/usecases/__tests__/GeneratePersonasFromInterviewsUseCase.test.ts
@@ -205,7 +205,7 @@ describe('GeneratePersonasFromInterviewsUseCase', () => {
     expect(mockGenerateUseCase.execute).toHaveBeenCalledTimes(1);
     expect(mockGenerateUseCase.execute).toHaveBeenCalledWith(
       expect.any(String),
-      undefined,
+      expect.any(Function),
       expect.any(Number),
     );
 
@@ -383,7 +383,7 @@ describe('GeneratePersonasFromInterviewsUseCase', () => {
     );
 
     await expect(useCase.execute(transcripts)).rejects.toThrow(
-      'Only 0 interview(s) extracted successfully. Need at least 2.',
+      'No interviews extracted successfully. At least one is required.',
     );
 
     expect(poolSignals).not.toHaveBeenCalled();
@@ -405,16 +405,23 @@ describe('GeneratePersonasFromInterviewsUseCase', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // 7b) Minimum 2 successful extractions requirement
+  // 7b) Single successful extraction is enough
   // ---------------------------------------------------------------------------
-  it('should throw when fewer than 2 extractions succeed', async () => {
+  it('should proceed when only 1 extraction succeeds', async () => {
     mockLlmService.extractInterviewSignals
       .mockResolvedValueOnce(baseSignal)
       .mockRejectedValueOnce(new Error('fail'))
       .mockRejectedValueOnce(new Error('fail'));
 
-    await expect(useCase.execute(transcripts)).rejects.toThrow(
-      'Only 1 interview(s) extracted successfully. Need at least 2.',
-    );
+    vi.mocked(poolSignals).mockReturnValue(mockDistribution);
+    vi.mocked(samplePersonas).mockResolvedValue([mockSampledSignals[0]]);
+    mockGenerateUseCase.execute.mockResolvedValue(mockPersonas);
+
+    const result = await useCase.execute(transcripts);
+
+    expect(result).toHaveLength(2);
+    expect(poolSignals).toHaveBeenCalled();
+    expect(samplePersonas).toHaveBeenCalled();
+    expect(mockGenerateUseCase.execute).toHaveBeenCalled();
   });
 });

--- a/src/ui/interviews/InterviewUploadClient.tsx
+++ b/src/ui/interviews/InterviewUploadClient.tsx
@@ -240,18 +240,9 @@ export function InterviewUploadClient() {
                 <p className="text-sm text-muted-foreground">
                   {files.length === 0
                     ? 'Upload interview transcripts above to get started.'
-                    : files.length === 1
-                      ? `${files.length} transcript uploaded. Need at least 2 to generate interview-grounded personas.`
-                      : `${files.length} transcripts uploaded. Ready to extract signals and generate personas.`}
+                    : `${files.length} transcript${files.length !== 1 ? 's' : ''} uploaded. Ready to extract signals and generate personas.`}
                 </p>
               </div>
-
-              {files.length === 1 && (
-                <p className="text-sm text-amber-400 font-medium bg-amber-400/10 p-3 rounded-md flex items-center gap-2">
-                  <span className="text-base">⚠️</span>
-                  Need at least 2 interview transcripts to generate personas. Upload one more to proceed.
-                </p>
-              )}
 
               <div className="flex flex-col gap-2">
                 <label className="text-sm font-medium text-muted-foreground">
@@ -289,11 +280,11 @@ export function InterviewUploadClient() {
               <div className="flex justify-end">
                 <button
                   type="button"
-                  disabled={files.length < 2 || isPending}
+                  disabled={files.length === 0 || isPending}
                   onClick={handleSubmit}
                   className="inline-flex h-12 items-center justify-center rounded-md bg-primary px-8 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
                 >
-                  {isPending ? 'Processing...' : files.length < 2 ? 'Need 2+ Transcripts' : 'Generate Personas from Interviews'}
+                  {isPending ? 'Processing...' : files.length === 0 ? 'Upload Transcripts First' : 'Generate Personas from Interviews'}
                 </button>
               </div>
 


### PR DESCRIPTION
Removes the minimum-2-interview constraint across the full pipeline:

- **UI**: removes 'need at least 2' warning and button disable; now only disables when 0 files uploaded
- **Use case**: changes extraction guard from `< 2` to `=== 0` successful extractions
- **Tests**: updates error messages and repurposes old 'throws when < 2' test to verify single-extraction path works