### PR TITLE
Add dual-mode persona generation with provenance tracking

### DIFF
--- a/.serena/memories/persona/persona-modeling-philosophy.md
+++ b/.serena/memories/persona/persona-modeling-philosophy.md
@@ -1,0 +1,35 @@
+# Persona Modeling Philosophy Implementation
+
+Implemented Mar 2025 as PR #62 on feat/persona-modeling-overhaul branch.
+
+## Dual-mode generation
+
+Three modes with distinct rules:
+
+| Mode | Evidence | Invention | Backstory | Use case |
+|------|----------|-----------|-----------|----------|
+| research | Required | None/minimal | 2-3 sentences, evidence-only | Interview-based personas |
+| strategy | Allowed | Controlled | Rich storytelling | ICP/market personas |
+| cluster | Required | Cluster-level | Minimal | Multi-interview synthesis |
+
+## Key files
+
+- `src/domain/entities/Persona.ts` — new fields: generationMode, behavioralDimensions, provenance, evidenceLinks, clusterInfo, identityContext, situationContext, counterfactualTest
+- `src/domain/entities/PersonaProvenance.ts` — tier labeling (observed/interpreted/synthetic), per-attribute confidence
+- `src/domain/entities/BehavioralDimension.ts` — context-specific behavioral axes (supplements Big Five)
+- `src/domain/dtos/PersonaGenerationConfig.ts` — config types for each generation mode (shared base schema, no discriminator in configs since method name IS the discriminator)
+- `src/domain/ports/LlmServicePort.ts` — new methods for research/strategy/cluster generation + streaming + counterfactual test
+- `src/infrastructure/adapters/PersonaAdapter.ts` — shared parsePersonaList/extractBaseFields/extractBehavioralDimensions helpers, mode-specific prompts
+- `src/application/usecases/GeneratePersonasUseCase.ts` — mode dispatch
+
+## Philosophy principles encoded
+
+1. Every persona detail should explain a decision, behavior, or need (not be a biography)
+2. Don't invent details that CREATE behavior; only invent details that EXPLAIN behavior
+3. Identity vs situation distinction: identityContext (stable traits) vs situationContext (contextual behavior)
+4. Counterfactual removal test: "If this detail were false, would the team make a different product decision?"
+5. Provenance: every attribute tracks its tier (observed/interpreted/synthetic) and confidence
+
+## Tests
+
+64 tests across domain, infrastructure, and application layers covering all three modes, count validation, error handling, and type safety.

--- a/src/actions/applyCounterfactualTest.ts
+++ b/src/actions/applyCounterfactualTest.ts
@@ -1,0 +1,18 @@
+"use server";
+
+import { Persona } from "@/domain/entities/Persona";
+import { LlmServiceImpl } from "@/infrastructure/adapters/LlmServiceImpl";
+
+import { shouldRunLocally } from "@/infrastructure/config";
+
+export async function applyCounterfactualTestAction(
+    persona: Persona,
+): Promise<{ detail: string; reason: string; attribute?: string }[]> {
+    if (!shouldRunLocally()) {
+        console.warn("[applyCounterfactualTestAction] Remote mode not supported yet");
+        return [];
+    }
+
+    const llmService = LlmServiceImpl.createFromEnv("openrouter");
+    return llmService.applyCounterfactualTest(persona);
+}

--- a/src/actions/generatePersonas.ts
+++ b/src/actions/generatePersonas.ts
@@ -19,14 +19,15 @@ const personasRateLimiter = new RateLimiterMemory({
 import { shouldRunLocally, VPS_BACKEND_URL, getVpsAuthToken } from "@/infrastructure/config";
 import { storeProgress, storeCompleted } from "@/actions/getProgress";
 import { personaGenerationStore } from "@/infrastructure/PersonaGenerationStore";
+import type { PersonaGenerationMode } from "@/domain/entities/PersonaProvenance";
 
 function generateRunId(): string {
   return `persona-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
 }
 
-async function runLocally(personaDescription: string, count: number) {
+async function runLocally(personaDescription: string, count: number, mode?: PersonaGenerationMode) {
     const runId = generateRunId();
-    console.log(`generatePersonasAction called [runId=${runId}]...`);
+    console.log(`generatePersonasAction called [runId=${runId}] mode=${mode ?? "default"}...`);
     const stream = createStreamableValue<any>({ step: "BRAINSTORMING_PERSONAS" });
 
     let clientIP = 'unknown';
@@ -62,7 +63,7 @@ async function runLocally(personaDescription: string, count: number) {
                     completedCount: progress.completedCount,
                     totalCount: progress.totalCount,
                 });
-            }, count);
+            }, count, undefined, mode);
 
             const finalPersonas = JSON.parse(JSON.stringify(personas));
             stream.done({ step: "DONE", personas: finalPersonas });
@@ -81,14 +82,14 @@ async function runLocally(personaDescription: string, count: number) {
     return { streamData: stream.value, runId };
 }
 
-async function runRemote(personaDescription: string, count: number) {
+async function runRemote(personaDescription: string, count: number, mode?: PersonaGenerationMode) {
     const res = await fetch(`${VPS_BACKEND_URL}/api/vps/generate-personas`, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${getVpsAuthToken()}`,
         },
-        body: JSON.stringify({ personaDescription, count }),
+        body: JSON.stringify({ personaDescription, count, mode }),
     });
 
     if (!res.ok) {
@@ -100,7 +101,11 @@ async function runRemote(personaDescription: string, count: number) {
     return { streamData: undefined as unknown as ReturnType<typeof createStreamableValue>['value'], runId: data.runId as string };
 }
 
-export async function generatePersonasAction(personaDescription: string, count: number = 5) {
-    if (shouldRunLocally()) return runLocally(personaDescription, count);
-    return runRemote(personaDescription, count);
+export async function generatePersonasAction(
+    personaDescription: string,
+    count: number = 5,
+    mode?: PersonaGenerationMode,
+) {
+    if (shouldRunLocally()) return runLocally(personaDescription, count, mode);
+    return runRemote(personaDescription, count, mode);
 }

--- a/src/actions/generatePersonasFromInterviews.ts
+++ b/src/actions/generatePersonasFromInterviews.ts
@@ -50,7 +50,7 @@ async function runLocally(formData: FormData) {
 
     const files: { filename: string; content: string }[] = [];
     let personaCount = 5;
-    let generationMode: 'individual' | 'synthesized' = 'synthesized';
+    let generationMode: 'individual' | 'synthesized' = 'individual';
     for (const [key, value] of formData.entries()) {
         if (value instanceof File && (key === "files" || key.startsWith("file_"))) {
             const content = await value.text();

--- a/src/actions/generatePersonasFromInterviews.ts
+++ b/src/actions/generatePersonasFromInterviews.ts
@@ -50,6 +50,7 @@ async function runLocally(formData: FormData) {
 
     const files: { filename: string; content: string }[] = [];
     let personaCount = 5;
+    let generationMode: 'individual' | 'synthesized' = 'synthesized';
     for (const [key, value] of formData.entries()) {
         if (value instanceof File && (key === "files" || key.startsWith("file_"))) {
             const content = await value.text();
@@ -57,6 +58,8 @@ async function runLocally(formData: FormData) {
         } else if (key === "count" && typeof value === "string") {
             const parsed = parseInt(value, 10);
             if (!isNaN(parsed) && parsed >= 1 && parsed <= 20) personaCount = parsed;
+        } else if (key === "mode" && typeof value === "string") {
+            if (value === 'individual' || value === 'synthesized') generationMode = value;
         }
     }
 
@@ -84,7 +87,7 @@ async function runLocally(formData: FormData) {
                     completedCount: progress.current,
                     totalCount: progress.total,
                 });
-            }, personaCount);
+            }, personaCount, generationMode);
 
             const finalPersonas = JSON.parse(JSON.stringify(personas));
             stream.done({ step: "DONE", personas: finalPersonas });

--- a/src/app/api/vps/generate-personas-from-interviews/route.ts
+++ b/src/app/api/vps/generate-personas-from-interviews/route.ts
@@ -53,6 +53,7 @@ export async function POST(req: NextRequest) {
     const formData = await req.formData();
     const files: { filename: string; content: string }[] = [];
     let personaCount = 5;
+    let generationMode: 'individual' | 'synthesized' = 'individual';
 
     for (const [key, value] of formData.entries()) {
         if (
@@ -64,6 +65,8 @@ export async function POST(req: NextRequest) {
         } else if (key === "count" && typeof value === "string") {
             const parsed = parseInt(value, 10);
             if (!isNaN(parsed) && parsed >= 1 && parsed <= 20) personaCount = parsed;
+        } else if (key === "mode" && typeof value === "string") {
+            if (value === 'individual' || value === 'synthesized') generationMode = value;
         }
     }
 
@@ -80,7 +83,7 @@ export async function POST(req: NextRequest) {
     // ── Generate runId and kick off background processing ───────────────────
     const runId = `pi-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
 
-    runPipeline(runId, files, personaCount).catch((err) => {
+    runPipeline(runId, files, personaCount, generationMode).catch((err) => {
         console.error(`[generate-personas-from-interviews] Background pipeline failed for ${runId}:`, err);
     });
 
@@ -95,6 +98,7 @@ async function runPipeline(
     runId: string,
     files: { filename: string; content: string }[],
     count: number,
+    generationMode: 'individual' | 'synthesized',
 ) {
     try {
         storeProgress(runId, { step: "PARSING_FILES" });
@@ -118,7 +122,7 @@ async function runPipeline(
                 completedAnalyses: progress.current,
                 totalAnalyses: progress.total,
             });
-        }, count);
+        }, count, generationMode);
 
         const serialized = JSON.parse(JSON.stringify(personas));
         personaGenerationStore.save(runId, serialized);

--- a/src/application/usecases/GeneratePersonasFromInterviewsUseCase.ts
+++ b/src/application/usecases/GeneratePersonasFromInterviewsUseCase.ts
@@ -75,6 +75,8 @@ function formatPersonaDescription(signal: SampledPersonaSignal): string {
     return lines.join('\n');
 }
 
+export type InterviewGenerationMode = 'individual' | 'synthesized';
+
 export class GeneratePersonasFromInterviewsUseCase {
     constructor(
         private llmService: LlmServicePort,
@@ -86,6 +88,7 @@ export class GeneratePersonasFromInterviewsUseCase {
         transcripts: { filename: string; content: string }[],
         onProgress?: (progress: InterviewPipelineProgress) => void,
         count: number = 5,
+        mode: InterviewGenerationMode = 'synthesized',
     ): Promise<Persona[]> {
         if (transcripts.length === 0) {
             throw new Error("At least one interview transcript is required");
@@ -99,16 +102,16 @@ export class GeneratePersonasFromInterviewsUseCase {
                 const interviewId = `interview-${i}`;
                 onProgress?.({ step: 'EXTRACTING', total: transcripts.length, current: i + 1, message: t.filename });
                 const signals = await this.llmService.extractInterviewSignals(t.content, interviewId);
-                return { filename: t.filename, signals };
+                return { filename: t.filename, signals, content: t.content };
             }),
         );
 
         const unsuccessfulExtractions: { filename: string; reason: unknown }[] = [];
-        const successfulExtractions: ExtractedInterviewSignals[] = [];
+        const successfulExtractions: { signals: ExtractedInterviewSignals; content: string }[] = [];
 
         for (const result of extractionResults) {
             if (result.status === "fulfilled") {
-                successfulExtractions.push(result.value.signals);
+                successfulExtractions.push(result.value);
             } else {
                 console.warn(
                     `[GeneratePersonasFromInterviews] Extraction failed:`,
@@ -123,9 +126,88 @@ export class GeneratePersonasFromInterviewsUseCase {
             );
         }
 
+        // Mode: Individual — generate personas per interview
+        if (mode === 'individual') {
+            return this.generateIndividual(
+                successfulExtractions,
+                onProgress,
+                count,
+            );
+        }
+
+        // Mode: Synthesized — existing pool/sample/generate pipeline (default)
+        return this.generateSynthesized(
+            successfulExtractions.map(e => e.signals),
+            onProgress,
+            count,
+        );
+    }
+
+    private async generateIndividual(
+        successfulExtractions: { signals: ExtractedInterviewSignals; content: string }[],
+        onProgress?: (progress: InterviewPipelineProgress) => void,
+        personasPerInterview: number = 3,
+    ): Promise<Persona[]> {
+        const allPersonas: Persona[] = [];
+        const totalPersonas = successfulExtractions.length * personasPerInterview;
+        let completed = 0;
+
+        for (let i = 0; i < successfulExtractions.length; i++) {
+            const { signals, content } = successfulExtractions[i];
+            const interviewId = `interview-${i}`;
+            onProgress?.({
+                step: 'GENERATING',
+                message: `Generating personas from transcript ${i + 1}...`,
+                current: completed,
+                total: totalPersonas,
+            });
+
+            const description = `Interview transcript excerpt: ${content.slice(0, 1500)}
+
+Key signals extracted from this interview:
+Pain points:
+${signals.painPoints.map(s => `- ${s.text}`).join('\n')}
+Goals:
+${signals.goals.map(s => `- ${s.text}`).join('\n')}
+Values:
+${signals.values.map(s => `- ${s.text}`).join('\n')}
+Feature desires:
+${signals.featureDesires.map(s => `- ${s.text}`).join('\n')}
+Decision patterns:
+${signals.decisionPatterns.map(s => `- ${s.text}`).join('\n')}
+Context: role=${signals.context.role ?? 'unknown'}, industry=${signals.context.industry ?? 'unknown'}
+Communication style: ${signals.communicationStyle}`;
+
+            const personas = await this.llmService.generateResearchPersonas({
+                count: personasPerInterview,
+                personaDescription: description,
+                interviewIds: [interviewId],
+                evidenceThreshold: 0.7,
+            });
+
+            allPersonas.push(...personas);
+            completed += personas.length;
+
+            onProgress?.({
+                step: 'GENERATING',
+                message: `Generated ${completed}/${totalPersonas} personas`,
+                current: completed,
+                total: totalPersonas,
+            });
+        }
+
+        onProgress?.({ step: 'DONE', personas: allPersonas });
+        return allPersonas;
+    }
+
+    private async generateSynthesized(
+        extractedSignals: ExtractedInterviewSignals[],
+        onProgress?: (progress: InterviewPipelineProgress) => void,
+        count: number = 5,
+    ): Promise<Persona[]> {
         // Phase 2: Pool — aggregate signals into weighted distribution
         onProgress?.({ step: 'POOLING' });
-        const distribution = poolSignals(successfulExtractions);
+        const distribution = poolSignals(extractedSignals);
 
         // Phase 3: Sample — weighted draw with LLM-based coherence validation
         onProgress?.({ step: 'SAMPLING' });
@@ -143,8 +225,6 @@ export class GeneratePersonasFromInterviewsUseCase {
             .join('\n\n---\n\n');
 
         // Phase 5: Generate — delegate to GeneratePersonasUseCase for full persona creation
-        // Forward sub-step progress (backstories, behavioral depth, etc.) so the UI
-        // shows actual progress during this long-running phase instead of staying stuck.
         onProgress?.({ step: 'GENERATING', message: 'Generating personas from interview signals' });
         const personas = await this.generatePersonasUseCase.execute(
             combinedDescription,
@@ -167,7 +247,7 @@ export class GeneratePersonasFromInterviewsUseCase {
                 persona.id,
                 persona.backstory ?? '',
             );
-            const interviewChunks = successfulExtractions.flatMap(
+            const interviewChunks = extractedSignals.flatMap(
                 (signals) => chunkInterviewSignals(signals, persona.id),
             );
             const allChunks: Chunk[] = [...backstoryChunks, ...interviewChunks];

--- a/src/application/usecases/GeneratePersonasFromInterviewsUseCase.ts
+++ b/src/application/usecases/GeneratePersonasFromInterviewsUseCase.ts
@@ -224,21 +224,16 @@ Communication style: ${signals.communicationStyle}`;
             .map(formatPersonaDescription)
             .join('\n\n---\n\n');
 
-        // Phase 5: Generate — delegate to GeneratePersonasUseCase for full persona creation
-        onProgress?.({ step: 'GENERATING', message: 'Generating personas from interview signals' });
-        const personas = await this.generatePersonasUseCase.execute(
-            combinedDescription,
-            onProgress ? (inner) => {
-                onProgress({
-                    step: 'GENERATING',
-                    message: inner.streamingText ?? inner.step,
-                    current: inner.completedCount,
-                    total: inner.totalCount,
-                });
-            } : undefined,
-            targetCount,
-            combinedDescription,
-        );
+        // Phase 5: Generate — use research mode for evidence-grounded personas
+        // Research mode keeps backstories minimal (2-3 evidence-based sentences)
+        // and avoids Tier 4 fabricated memories (trauma, fake events, fake purchases)
+        onProgress?.({ step: 'GENERATING', message: 'Generating evidence-grounded personas' });
+        const personas = await this.llmService.generateResearchPersonas({
+            count: targetCount,
+            personaDescription: combinedDescription,
+            interviewIds: extractedSignals.map((_, i) => `interview-${i}`),
+            evidenceThreshold: 0.7,
+        });
 
         // Phase 6: Ingest — store backstory and interview chunks in ID-RAG store
         onProgress?.({ step: 'INGESTING' });

--- a/src/application/usecases/GeneratePersonasUseCase.ts
+++ b/src/application/usecases/GeneratePersonasUseCase.ts
@@ -50,6 +50,20 @@ export class GeneratePersonasUseCase {
                 personaDescription,
                 contextNotes,
             });
+
+            // Run PB&J rationalization for research mode, store in pbjRationales
+            // Capture backstories BEFORE calling rationalizePersonas (which mutates in-place)
+            const backstoriesBefore = personas.map(p => p.backstory ?? '');
+            const rationalized = await this.llmService.rationalizePersonas(personas, contextNotes);
+            for (let i = 0; i < personas.length; i++) {
+                const enhanced = rationalized[i]?.backstory ?? backstoriesBefore[i];
+                const pbjMatch = enhanced.match(/<<PSYCHOLOGICAL RATIONALES \(PB&J\)>>[\s\S]*$/);
+                if (pbjMatch && personas[i]) {
+                    personas[i].pbjRationales = pbjMatch[0].trim();
+                    personas[i].backstory = backstoriesBefore[i];
+                }
+            }
+
             return personas;
         }
 
@@ -149,8 +163,17 @@ export class GeneratePersonasUseCase {
             streamingText: `Phase 3 of 3: Connecting traits to behavior...`,
         });
 
+        const backstoriesBeforePbj = personas.map(p => p.backstory ?? '');
         personas = await this.llmService.rationalizePersonas(personas, contextNotes);
-        console.log("[GeneratePersonasUseCase] PB&J enhancement complete for all personas");
+        for (let i = 0; i < personas.length; i++) {
+            const enhanced = personas[i]?.backstory ?? backstoriesBeforePbj[i];
+            const pbjMatch = enhanced.match(/<<PSYCHOLOGICAL RATIONALES \(PB&J\)>>[\s\S]*$/);
+            if (pbjMatch && personas[i]) {
+                personas[i].pbjRationales = pbjMatch[0].trim();
+                personas[i].backstory = backstoriesBeforePbj[i];
+            }
+        }
+        console.log("[GeneratePersonasUseCase] PB&J extraction complete");
 
         return personas;
     }

--- a/src/application/usecases/GeneratePersonasUseCase.ts
+++ b/src/application/usecases/GeneratePersonasUseCase.ts
@@ -20,8 +20,10 @@ export interface PersonaGenerationProgress {
     streamingText?: string; // For live UI feedback
 }
 
+import type { PersonaGenerationMode } from "@/domain/entities/PersonaProvenance";
+
 export class GeneratePersonasUseCase {
-    private static readonly ABBREVIATE_BACKSTORIES = true; // Toggle this for fast testing
+    private static readonly ABBREVIATE_BACKSTORIES = true;
 
     constructor(private llmService: LlmServicePort) { }
 
@@ -29,21 +31,49 @@ export class GeneratePersonasUseCase {
         personaDescription: string,
         onProgress?: (progress: PersonaGenerationProgress) => void,
         count?: number,
-        contextNotes?: string
+        contextNotes?: string,
+        mode?: PersonaGenerationMode,
     ): Promise<Persona[]> {
-        console.log("Executing GeneratePersonas use case");
+        console.log(`[GeneratePersonasUseCase] Executing in ${mode ?? "strategy (default)"} mode`);
 
-        // Generate personas via non-streaming call (reliable, no stream issues)
         onProgress?.({
             step: 'BRAINSTORMING_PERSONAS',
             streamingText: "Generating persona profiles..."
         });
 
-        // Retry once on count mismatch — LLMs sometimes return wrong counts despite prompt enforcement
-        let personas: Persona[] | null = null;
+        let personas: Persona[];
+        const targetCount = count ?? 3;
+
+        if (mode === 'research') {
+            personas = await this.llmService.generateResearchPersonas({
+                count: targetCount,
+                personaDescription,
+                contextNotes,
+            });
+            return personas;
+        }
+
+        if (mode === 'strategy') {
+            personas = await this.llmService.generateStrategyPersonas({
+                count: targetCount,
+                personaDescription,
+                contextNotes,
+                allowSyntheticBackstory: true,
+                storytellingLevel: 'moderate',
+            });
+            return personas;
+        }
+
+        if (mode === 'cluster') {
+            throw new Error("Cluster mode requires interview IDs. Use GeneratePersonasFromInterviewsUseCase instead.");
+        }
+
+        // Default (undefined mode): legacy pipeline for backward compatibility
+        // Retry once on count mismatch
+        let initialPersonas: Persona[] | null = null;
         for (let attempt = 0; attempt < 2; attempt++) {
             try {
-                personas = await this.llmService.generateInitialPersonas(personaDescription, count);
+                initialPersonas = await this.llmService.generateInitialPersonas(personaDescription, targetCount);
                 break;
             } catch (err) {
                 const msg = (err as Error).message ?? '';
@@ -55,20 +85,20 @@ export class GeneratePersonasUseCase {
                     });
                     continue;
                 }
-                throw err; // Non-count errors or second failure — propagate
+                throw err;
             }
         }
-
-        if (!personas || personas.length === 0) {
+        if (!initialPersonas || initialPersonas.length === 0) {
             throw new Error("Failed to generate any personas from the description");
         }
+        personas = initialPersonas;
 
+        // Legacy pipeline: add backstories + PB&J rationalization
         console.log(`[GeneratePersonasUseCase] Generated ${personas.length} personas`);
 
         const abbreviate = GeneratePersonasUseCase.ABBREVIATE_BACKSTORIES;
         const subStepsPerPersona = abbreviate ? 1 : 4;
 
-        // Broadcast initial personas immediately for UI responsiveness
         onProgress?.({
             step: 'GENERATING_BACKSTORIES',
             personaName: personas[0]?.name,
@@ -83,8 +113,6 @@ export class GeneratePersonasUseCase {
         const totalCount = personas.length;
         const totalSubSteps = totalCount * subStepsPerPersona;
 
-        // OPTIMIZATION: Use batch generation instead of per-persona calls
-        // This reduces 3 LLM calls to 1 for backstories
         console.log("[GeneratePersonasUseCase] Generating batch backstories...");
         onProgress?.({
             step: 'GENERATING_BACKSTORIES',
@@ -94,10 +122,10 @@ export class GeneratePersonasUseCase {
             completedCount: 0,
             totalSubSteps,
             completedSubSteps: 0,
-            streamingText: `Phase 2 of 4: Building stories...`,
+            streamingText: `Phase 2 of 3: Building stories...`,
         });
 
-        const backstoryTexts = await (this.llmService as any).generateAbbreviatedBackstoriesBatch(personas);
+        const backstoryTexts = await this.llmService.generateAbbreviatedBackstoriesBatch(personas);
         personas.forEach((persona, i) => {
             persona.backstory = backstoryTexts[i];
         });
@@ -111,8 +139,6 @@ export class GeneratePersonasUseCase {
             personas: JSON.parse(JSON.stringify(personas))
         });
 
-        // Phase 3: PB&J Rationalization — causally connect Big Five to psychographics
-        // Joshi et al. (2025): improves persona alignment by 6-9% over backstory-only
         console.log("[GeneratePersonasUseCase] Enhancing personas with PB&J psychological rationales...");
         onProgress?.({
             step: 'ADDING_BEHAVIORAL_DEPTH',
@@ -120,7 +146,7 @@ export class GeneratePersonasUseCase {
             personas: JSON.parse(JSON.stringify(personas)),
             totalCount,
             completedCount: 0,
-            streamingText: `Phase 3 of 4: Connecting traits to behavior...`,
+            streamingText: `Phase 3 of 3: Connecting traits to behavior...`,
         });
 
         personas = await this.llmService.rationalizePersonas(personas, contextNotes);

--- a/src/application/usecases/__tests__/GeneratePersonasUseCase.test.ts
+++ b/src/application/usecases/__tests__/GeneratePersonasUseCase.test.ts
@@ -59,6 +59,7 @@ describe('GeneratePersonasUseCase', () => {
 
   it('should dispatch to research mode when specified', async () => {
     mockLlmService.generateResearchPersonas.mockResolvedValue([{ ...fullPersona, generationMode: 'research' } as Persona]);
+    mockLlmService.rationalizePersonas.mockImplementation(async (ps: Persona[]) => ps);
 
     const results = await useCase.execute('Test description', undefined, 1, undefined, 'research');
 
@@ -72,13 +73,16 @@ describe('GeneratePersonasUseCase', () => {
       .rejects.toThrow("Cluster mode requires interview IDs");
   });
 
-  it('should skip PB&J rationalization for research mode', async () => {
-    mockLlmService.generateResearchPersonas.mockResolvedValue([{ ...fullPersona, generationMode: 'research' } as Persona]);
+  it('should run PB&J for research mode but store in pbjRationales', async () => {
+    const researchPersona = { ...fullPersona, generationMode: 'research' } as Persona;
+    mockLlmService.generateResearchPersonas.mockResolvedValue([researchPersona]);
+    mockLlmService.rationalizePersonas.mockImplementation(async (ps: Persona[]) => ps);
 
-    await useCase.execute('Test', undefined, 1, undefined, 'research');
+    const results = await useCase.execute('Test', undefined, 1, undefined, 'research');
 
-    expect(mockLlmService.rationalizePersonas).not.toHaveBeenCalled();
+    expect(mockLlmService.rationalizePersonas).toHaveBeenCalled();
     expect(mockLlmService.generateAbbreviatedBackstoriesBatch).not.toHaveBeenCalled();
+    expect(results[0].pbjRationales).toBeUndefined(); // no PB&J section to extract since mock returns same persona
   });
 
   it('should dispatch to strategy mode when specified', async () => {

--- a/src/application/usecases/__tests__/GeneratePersonasUseCase.test.ts
+++ b/src/application/usecases/__tests__/GeneratePersonasUseCase.test.ts
@@ -33,12 +33,15 @@ describe('GeneratePersonasUseCase', () => {
       generateInitialPersonas: vi.fn(),
       generateAbbreviatedBackstoriesBatch: vi.fn(),
       rationalizePersonas: vi.fn(),
+      generateResearchPersonas: vi.fn(),
+      generateStrategyPersonas: vi.fn(),
+      generateClusterPersonas: vi.fn(),
     } as any;
 
     useCase = new GeneratePersonasUseCase(mockLlmService);
   });
 
-  it('should generate personas with backstories and rationalization', async () => {
+  it('should generate personas with backstories and rationalization (default mode)', async () => {
     const description = 'Busy founders';
 
     mockLlmService.generateInitialPersonas.mockResolvedValue([{ ...fullPersona }]);
@@ -47,27 +50,45 @@ describe('GeneratePersonasUseCase', () => {
 
     const results = await useCase.execute(description);
 
-    expect(mockLlmService.generateInitialPersonas).toHaveBeenCalledWith(description, undefined);
+    expect(mockLlmService.generateInitialPersonas).toHaveBeenCalledWith(description, 3);
     expect(mockLlmService.generateAbbreviatedBackstoriesBatch).toHaveBeenCalled();
     expect(mockLlmService.rationalizePersonas).toHaveBeenCalled();
     expect(results.length).toBe(1);
     expect(results[0].backstory).toBe('backstory content');
   });
 
-  it('should handle multiple personas', async () => {
-    const personas = [
-      { ...fullPersona, id: '1', name: 'Persona 1' },
-      { ...fullPersona, id: '2', name: 'Persona 2' },
-      { ...fullPersona, id: '3', name: 'Persona 3' }
-    ];
+  it('should dispatch to research mode when specified', async () => {
+    mockLlmService.generateResearchPersonas.mockResolvedValue([{ ...fullPersona, generationMode: 'research' } as Persona]);
 
-    mockLlmService.generateInitialPersonas.mockResolvedValue(personas);
-    mockLlmService.generateAbbreviatedBackstoriesBatch.mockResolvedValue(['a', 'b', 'c']);
-    mockLlmService.rationalizePersonas.mockImplementation(async (ps: Persona[]) => ps);
+    const results = await useCase.execute('Test description', undefined, 1, undefined, 'research');
 
-    await useCase.execute('description');
+    expect(mockLlmService.generateResearchPersonas).toHaveBeenCalled();
+    expect(results[0].generationMode).toBe('research');
+    expect(mockLlmService.generateInitialPersonas).not.toHaveBeenCalled();
+  });
 
-    expect(mockLlmService.generateInitialPersonas).toHaveBeenCalled();
-    expect(mockLlmService.generateAbbreviatedBackstoriesBatch).toHaveBeenCalled();
+  it('should throw when cluster mode is used without interview IDs', async () => {
+    await expect(useCase.execute('Test', undefined, 1, undefined, 'cluster'))
+      .rejects.toThrow("Cluster mode requires interview IDs");
+  });
+
+  it('should skip PB&J rationalization for research mode', async () => {
+    mockLlmService.generateResearchPersonas.mockResolvedValue([{ ...fullPersona, generationMode: 'research' } as Persona]);
+
+    await useCase.execute('Test', undefined, 1, undefined, 'research');
+
+    expect(mockLlmService.rationalizePersonas).not.toHaveBeenCalled();
+    expect(mockLlmService.generateAbbreviatedBackstoriesBatch).not.toHaveBeenCalled();
+  });
+
+  it('should dispatch to strategy mode when specified', async () => {
+    mockLlmService.generateStrategyPersonas.mockResolvedValue([{ ...fullPersona, generationMode: 'strategy' } as Persona]);
+
+    const results = await useCase.execute('Test description', undefined, 1, undefined, 'strategy');
+
+    expect(mockLlmService.generateStrategyPersonas).toHaveBeenCalled();
+    expect(results[0].generationMode).toBe('strategy');
+    expect(mockLlmService.generateInitialPersonas).not.toHaveBeenCalled();
+    expect(mockLlmService.rationalizePersonas).not.toHaveBeenCalled();
   });
 });

--- a/src/components/custom/PersonaDetailSheet.tsx
+++ b/src/components/custom/PersonaDetailSheet.tsx
@@ -350,24 +350,10 @@ export function PersonaDetailSheet({
                         </div>
                     </div>
 
-                    {/* Profile Tab */}
                     {/* Profile Tab — Read Mode */}
                     {activeTab === "profile" && !isEditing && (
                         <ScrollArea className="flex-1 min-h-0">
-                            <div className="p-5 flex flex-col gap-5">
-
-                                {/* Quick Info */}
-                                <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-                                    <span>{persona.age} years old</span>
-                                    <span className="w-1 h-1 rounded-full bg-border" />
-                                    <span>{persona.educationLevel}</span>
-                                    {persona.decisionStyle && (
-                                        <>
-                                            <span className="w-1 h-1 rounded-full bg-border" />
-                                            <span>{persona.decisionStyle} decider</span>
-                                        </>
-                                    )}
-                                </div>
+                            <div className="p-5 flex flex-col gap-6">
 
                                 {/* Counterfactual Results */}
                                 {counterfactualResults && counterfactualResults.length > 0 && (
@@ -390,53 +376,10 @@ export function PersonaDetailSheet({
                                     </div>
                                 )}
 
-                                {/* Backstory */}
+                                {/* Behavioral Model — derived from behavioralDimensions or existing data */}
                                 <div className="flex flex-col gap-3">
-                                    <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">THE BACKSTORY VAULT</h4>
-                                    <div className="relative">
-                                        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-muted-foreground/50" />
-                                        <Input
-                                            placeholder="Search backstory..."
-                                            value={searchTerm}
-                                            onChange={(e) => setSearchTerm(e.target.value)}
-                                            className="h-8 text-xs pl-8 rounded-md bg-muted/30 border-none transition-all focus:ring-1 focus:ring-primary/20"
-                                        />
-                                    </div>
-                                    <div className="flex flex-col gap-4 max-h-[240px] overflow-y-auto custom-scrollbar pr-1">
-                                        {filteredBackstory.map((paragraph, i) => (
-                                            <p
-                                                key={`${persona.id}-para-${i}`}
-                                                className={cn(
-                                                    "text-sm md:text-base leading-relaxed text-foreground/80",
-                                                    searchTerm && paragraph.toLowerCase().includes(searchTerm.toLowerCase())
-                                                        ? "bg-primary/10 rounded-lg p-2 text-foreground font-medium ring-1 ring-primary/20" : ""
-                                                )}
-                                            >
-                                                {paragraph}
-                                            </p>
-                                        ))}
-                                    </div>
-                                </div>
-
-                                {/* Goals */}
-                                {persona.goals.length > 0 && (
-                                    <div className="flex flex-col gap-3">
-                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">GOALS</h4>
-                                        <ul className="space-y-2">
-                                            {persona.goals.map((goal, i) => (
-                                                <li key={`${persona.id}-goal-${i}`} className="text-xs md:text-sm flex gap-2 leading-relaxed">
-                                                    <span className="text-primary font-bold shrink-0">•</span>
-                                                    {goal}
-                                                </li>
-                                            ))}
-                                        </ul>
-                                    </div>
-                                )}
-
-                                {/* Behavioral Dimensions */}
-                                {persona.behavioralDimensions && persona.behavioralDimensions.length > 0 && (
-                                    <div className="flex flex-col gap-3">
-                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">BEHAVIOR MODEL</h4>
+                                    <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">BEHAVIOR</h4>
+                                    {persona.behavioralDimensions && persona.behavioralDimensions.length > 0 ? (
                                         <div className="space-y-3">
                                             {persona.behavioralDimensions.map((dim, i) => (
                                                 <div key={i} className="flex flex-col gap-1.5" style={{ opacity: attrOpacity(dim.evidence ? 'observed' : undefined) }}>
@@ -449,7 +392,7 @@ export function PersonaDetailSheet({
                                                         <span>{dim.context}</span>
                                                         {dim.evidence && (
                                                             <span className="text-primary/60 flex items-center gap-1" title={dim.evidence}>
-                                                                ● observed
+                                                                ● evidence
                                                             </span>
                                                         )}
                                                     </div>
@@ -457,85 +400,135 @@ export function PersonaDetailSheet({
                                                 </div>
                                             ))}
                                         </div>
-                                    </div>
-                                )}
-
-                                {/* Big Five (demoted) */}
-                                <details className="flex flex-col gap-4 group">
-                                    <summary className="text-xs font-bold text-muted-foreground uppercase tracking-widest cursor-pointer hover:text-foreground transition-colors list-none flex items-center gap-2">
-                                        <span className="text-[10px] text-muted-foreground/40 group-open:rotate-90 transition-transform">▶</span>
-                                        PERSONALITY TRAITS (BIG FIVE)
-                                    </summary>
-                                    <div className="space-y-4 pt-2">
-                                        {renderScalar("Conscientiousness", persona.conscientiousness, "Chaotic", "Meticulous")}
-                                        {renderScalar("Neuroticism", persona.neuroticism, "Stable", "Anxious")}
-                                        {renderScalar("Openness", persona.openness, "Traditional", "Curious")}
-                                        {renderScalar("Extraversion", persona.extraversion, "Introvert", "Extrovert")}
-                                        {renderScalar("Agreeableness", persona.agreeableness, "Competitive", "Compassionate")}
-                                    </div>
-                                </details>
-
-                                {/* Psychographic */}
-                                <div className="flex flex-col gap-4">
-                                    <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">PSYCHOGRAPHIC SPECIFICATION</h4>
-                                    {persona.values && persona.values.length > 0 && (
+                                    ) : (
                                         <div className="flex flex-col gap-2">
-                                            <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Values</span>
-                                            <div className="flex flex-wrap gap-1.5">
-                                                {persona.values.map((v, i) => (
-                                                    <span key={i} className="text-xs font-medium bg-primary/10 text-primary px-2.5 py-1 rounded-sm">{v}</span>
-                                                ))}
-                                            </div>
-                                        </div>
-                                    )}
-                                    {persona.fears && persona.fears.length > 0 && (
-                                        <div className="flex flex-col gap-2">
-                                            <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Fears</span>
-                                            <ul className="space-y-1.5">
-                                                {persona.fears.map((f, i) => (
-                                                    <li key={i} className="text-xs md:text-sm flex gap-2 leading-relaxed text-foreground/80">
-                                                        <span className="text-destructive shrink-0">•</span>
-                                                        {f}
-                                                    </li>
-                                                ))}
-                                            </ul>
-                                        </div>
-                                    )}
-                                    {persona.communicationStyle && (
-                                        <div className="flex items-center justify-between py-2 border-t border-border/20">
-                                            <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Communication</span>
-                                            <span className="text-xs md:text-sm font-medium capitalize">{persona.communicationStyle}</span>
+                                            {persona.goals.length > 0 && (
+                                                <div className="flex flex-col gap-2">
+                                                    {persona.goals.map((goal, i) => (
+                                                        <div key={i} className="flex items-center gap-2 text-xs text-foreground/80">
+                                                            <span className="text-primary shrink-0">✓</span>
+                                                            {goal}
+                                                        </div>
+                                                    ))}
+                                                </div>
+                                            )}
+                                            {persona.communicationStyle && (
+                                                <p className="text-xs text-muted-foreground/70 mt-1">
+                                                    Communicates {persona.communicationStyle}
+                                                </p>
+                                            )}
                                         </div>
                                     )}
                                 </div>
 
-                                {/* Identity vs Situation Context */}
-                                {(persona.identityContext || persona.situationContext) && (
-                                    <div className="flex flex-col gap-3">
-                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">CONTEXT</h4>
-                                        {persona.identityContext && (
-                                            <div className="flex flex-col gap-1">
-                                                <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Stable traits</span>
-                                                <p className="text-sm text-foreground/80">{persona.identityContext}</p>
-                                            </div>
-                                        )}
-                                        {persona.situationContext && (
-                                            <div className="flex flex-col gap-1">
-                                                <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Situational behavior</span>
-                                                <p className="text-sm text-foreground/80">{persona.situationContext}</p>
-                                            </div>
-                                        )}
+                                {/* Motivations — from values */}
+                                {persona.values && persona.values.length > 0 && (
+                                    <div className="flex flex-col gap-2">
+                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">MOTIVATIONS</h4>
+                                        <div className="flex flex-wrap gap-1.5">
+                                            {persona.values.map((v, i) => (
+                                                <span key={i} className="inline-flex items-center gap-1.5 text-xs font-medium bg-primary/10 text-primary px-2.5 py-1 rounded-sm">
+                                                    <span className="w-1.5 h-1.5 rounded-full bg-primary" />
+                                                    {v}
+                                                </span>
+                                            ))}
+                                        </div>
                                     </div>
                                 )}
 
-                                {/* Evidence Links */}
+                                {/* Frictions — from fears */}
+                                {persona.fears && persona.fears.length > 0 && (
+                                    <div className="flex flex-col gap-2">
+                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">FRICTIONS</h4>
+                                        <ul className="space-y-1.5">
+                                            {persona.fears.map((f, i) => (
+                                                <li key={i} className="text-xs text-foreground/80 flex gap-2">
+                                                    <span className="text-destructive shrink-0">✕</span>
+                                                    {f}
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    </div>
+                                )}
+
+                                {/* Decision Model */}
+                                <div className="flex flex-col gap-2">
+                                    <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">DECISION MODEL</h4>
+                                    {persona.decisionStyle && (
+                                        <p className="text-xs text-foreground/80">
+                                            Decision style: <span className="font-medium text-foreground">{persona.decisionStyle}</span>
+                                        </p>
+                                    )}
+                                    <div className="flex gap-3 text-xs text-muted-foreground/80">
+                                        <span>Price sensitivity: {persona.pricingSensitivity}/100</span>
+                                        {persona.typicalBudget && <span>· Budget: {persona.typicalBudget}</span>}
+                                    </div>
+                                    {persona.goals.length > 0 && (
+                                        <div className="mt-1 flex flex-col gap-1">
+                                            <span className="text-[11px] font-medium text-green-700">Likely to adopt if helps with:</span>
+                                            {persona.goals.slice(0, 3).map((g, i) => (
+                                                <span key={i} className="text-xs text-green-700/80 ml-2">✓ {g}</span>
+                                            ))}
+                                        </div>
+                                    )}
+                                </div>
+
+                                {/* Evidence & Confidence */}
+                                <div className="flex flex-col gap-2">
+                                    <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">EVIDENCE &amp; CONFIDENCE</h4>
+                                    {persona.provenance ? (
+                                        <div className="flex flex-col gap-2">
+                                            <div className="flex items-center gap-2 text-xs text-foreground/80">
+                                                <span>Overall confidence:</span>
+                                                <div className="flex-1 h-1.5 max-w-[120px] rounded-full bg-secondary">
+                                                    <div
+                                                        className="h-full rounded-full bg-primary transition-all"
+                                                        style={{ width: `${persona.provenance.overallConfidence * 100}%` }}
+                                                    />
+                                                </div>
+                                                <span className="font-mono text-muted-foreground">
+                                                    {Math.round(persona.provenance.overallConfidence * 100)}%
+                                                </span>
+                                            </div>
+                                            {persona.provenance.attributes.length > 0 && (
+                                                <details className="group">
+                                                    <summary className="text-xs text-muted-foreground hover:text-foreground cursor-pointer list-none flex items-center gap-1">
+                                                        <span className="text-[10px] text-muted-foreground/40 group-open:rotate-90 transition-transform">▶</span>
+                                                        Per-attribute breakdown ({persona.provenance.attributes.length})
+                                                    </summary>
+                                                    <div className="space-y-1 pt-1">
+                                                        {persona.provenance.attributes.map((attr, i) => (
+                                                            <div key={i} className="flex items-center gap-2 text-xs text-foreground/60">
+                                                                <span className={`w-1.5 h-1.5 rounded-full ${
+                                                                    attr.tier === 'observed' ? 'bg-green-500' :
+                                                                    attr.tier === 'interpreted' ? 'bg-amber-400' : 'bg-gray-300'
+                                                                }`} />
+                                                                <span>{attr.attribute}</span>
+                                                                <span className="text-muted-foreground/40">·</span>
+                                                                <span>{attr.tier}</span>
+                                                                <span className="text-muted-foreground/40">·</span>
+                                                                <span>{Math.round(attr.confidence * 100)}%</span>
+                                                            </div>
+                                                        ))}
+                                                    </div>
+                                                </details>
+                                            )}
+                                        </div>
+                                    ) : (
+                                        <p className="text-xs text-muted-foreground/60">
+                                            {persona.generationMode === 'research'
+                                                ? "No provenance data available"
+                                                : "This persona was generated from a description, not from interviews. Individual attributes are not linked to specific sources."
+                                            }
+                                        </p>
+                                    )}
+                                </div>
+
+                                {/* Sources */}
                                 {persona.evidenceLinks && persona.evidenceLinks.length > 0 && (
-                                    <details className="flex flex-col gap-3 group">
-                                        <summary className="text-xs font-bold text-muted-foreground uppercase tracking-widest cursor-pointer hover:text-foreground transition-colors list-none flex items-center gap-2">
-                                            <span className="text-[10px] text-muted-foreground/40 group-open:rotate-90 transition-transform">▶</span>
-                                            SOURCE EVIDENCE ({persona.evidenceLinks.length})
-                                        </summary>
-                                        <div className="space-y-2 pt-2">
+                                    <div className="flex flex-col gap-2">
+                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">SOURCES</h4>
+                                        <div className="space-y-2">
                                             {persona.evidenceLinks.map((link, i) => (
                                                 <div key={i} className="flex flex-col gap-1 rounded-lg border border-border/40 bg-secondary/20 p-3">
                                                     <span className="text-xs font-medium text-foreground">{link.attribute}</span>
@@ -544,23 +537,115 @@ export function PersonaDetailSheet({
                                                 </div>
                                             ))}
                                         </div>
-                                    </details>
-                                )}
-
-                                {/* Cluster Info */}
-                                {persona.clusterInfo && (
-                                    <div className="flex flex-col gap-2 rounded-lg border border-border/40 bg-secondary/20 p-3">
-                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">CLUSTER</h4>
-                                        <p className="text-xs text-muted-foreground/80">
-                                            Represents {persona.clusterInfo.representedCount} interview subjects
-                                        </p>
-                                        {persona.clusterInfo.sourceIds.length > 0 && (
-                                            <p className="text-xs text-muted-foreground/60">
-                                                Sources: {persona.clusterInfo.sourceIds.join(", ")}
-                                            </p>
-                                        )}
                                     </div>
                                 )}
+
+                                {/* Full Details — collapsible */}
+                                <details className="flex flex-col gap-3 group border-t border-border/20 pt-4">
+                                    <summary className="text-xs font-bold text-muted-foreground uppercase tracking-widest cursor-pointer hover:text-foreground transition-colors list-none flex items-center gap-2">
+                                        <span className="text-[10px] text-muted-foreground/40 group-open:rotate-90 transition-transform">▶</span>
+                                        FULL DETAILS
+                                    </summary>
+                                    <div className="flex flex-col gap-5 pt-3">
+
+                                        {/* Quick Info */}
+                                        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                                            <span>{persona.age} years old</span>
+                                            <span className="w-1 h-1 rounded-full bg-border" />
+                                            <span>{persona.educationLevel}</span>
+                                            {persona.occupation && (
+                                                <><span className="w-1 h-1 rounded-full bg-border" /><span>{persona.occupation}</span></>
+                                            )}
+                                        </div>
+
+                                        {/* Backstory */}
+                                        {persona.backstory && (
+                                            <div className="flex flex-col gap-3">
+                                                <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">BACKSTORY</h4>
+                                                <div className="relative">
+                                                    <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-muted-foreground/50" />
+                                                    <Input
+                                                        placeholder="Search backstory..."
+                                                        value={searchTerm}
+                                                        onChange={(e) => setSearchTerm(e.target.value)}
+                                                        className="h-8 text-xs pl-8 rounded-md bg-muted/30 border-none transition-all focus:ring-1 focus:ring-primary/20"
+                                                    />
+                                                </div>
+                                                <div className="flex flex-col gap-4 max-h-[240px] overflow-y-auto custom-scrollbar pr-1">
+                                                    {filteredBackstory.map((paragraph, i) => (
+                                                        <p key={`${persona.id}-para-${i}`}
+                                                            className={cn("text-sm md:text-base leading-relaxed text-foreground/80",
+                                                                searchTerm && paragraph.toLowerCase().includes(searchTerm.toLowerCase())
+                                                                    ? "bg-primary/10 rounded-lg p-2 text-foreground font-medium ring-1 ring-primary/20" : ""
+                                                            )}>
+                                                            {paragraph}
+                                                        </p>
+                                                    ))}
+                                                </div>
+                                            </div>
+                                        )}
+
+                                        {/* Big Five */}
+                                        <div className="flex flex-col gap-4">
+                                            <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">PERSONALITY (BIG FIVE)</h4>
+                                            <div className="space-y-4">
+                                                {renderScalar("Conscientiousness", persona.conscientiousness, "Chaotic", "Meticulous")}
+                                                {renderScalar("Neuroticism", persona.neuroticism, "Stable", "Anxious")}
+                                                {renderScalar("Openness", persona.openness, "Traditional", "Curious")}
+                                                {renderScalar("Extraversion", persona.extraversion, "Introvert", "Extrovert")}
+                                                {renderScalar("Agreeableness", persona.agreeableness, "Competitive", "Compassionate")}
+                                            </div>
+                                        </div>
+
+                                        {/* Psychographic */}
+                                        <div className="flex flex-col gap-3">
+                                            <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">PSYCHOGRAPHIC</h4>
+                                            {persona.communicationStyle && (
+                                                <p className="text-xs text-foreground/80">Communicates: {persona.communicationStyle}</p>
+                                            )}
+                                            {persona.interests && persona.interests.length > 0 && (
+                                                <div className="flex flex-wrap gap-1.5">
+                                                    {persona.interests.map((v, i) => (
+                                                        <span key={i} className="text-[11px] text-muted-foreground bg-secondary/40 px-2 py-0.5 rounded-sm">{v}</span>
+                                                    ))}
+                                                </div>
+                                            )}
+                                        </div>
+
+                                        {/* Identity/Situation Context */}
+                                        {(persona.identityContext || persona.situationContext) && (
+                                            <div className="flex flex-col gap-2">
+                                                {persona.identityContext && (
+                                                    <div className="flex flex-col gap-1">
+                                                        <span className="text-xs font-semibold text-muted-foreground">Stable traits</span>
+                                                        <p className="text-sm text-foreground/80">{persona.identityContext}</p>
+                                                    </div>
+                                                )}
+                                                {persona.situationContext && (
+                                                    <div className="flex flex-col gap-1">
+                                                        <span className="text-xs font-semibold text-muted-foreground">Situational</span>
+                                                        <p className="text-sm text-foreground/80">{persona.situationContext}</p>
+                                                    </div>
+                                                )}
+                                            </div>
+                                        )}
+
+                                        {/* Cluster Info */}
+                                        {persona.clusterInfo && (
+                                            <div className="flex flex-col gap-2 rounded-lg border border-border/40 bg-secondary/20 p-3">
+                                                <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">CLUSTER</h4>
+                                                <p className="text-xs text-muted-foreground/80">
+                                                    Represents {persona.clusterInfo.representedCount} interview subjects
+                                                </p>
+                                                {persona.clusterInfo.sourceIds.length > 0 && (
+                                                    <p className="text-xs text-muted-foreground/60">
+                                                        Sources: {persona.clusterInfo.sourceIds.join(", ")}
+                                                    </p>
+                                                )}
+                                            </div>
+                                        )}
+                                    </div>
+                                </details>
                             </div>
                         </ScrollArea>
                     )}

--- a/src/components/custom/PersonaDetailSheet.tsx
+++ b/src/components/custom/PersonaDetailSheet.tsx
@@ -14,8 +14,9 @@ import { Textarea } from "@/components/ui/textarea"
 import { PersonaAvatar } from "./PersonaAvatar"
 import { PersonaChatInline } from "@/ui/dashboard/components/chat/PersonaChatInline"
 import { PersonaTraitsSuggestionDialog, type SuggestedTraits } from "./PersonaTraitsSuggestionDialog"
-import { MessageSquare, User, Search, XIcon, CopyIcon, ShuffleIcon, SparklesIcon, PenIcon, LoaderIcon } from "lucide-react"
+import { MessageSquare, User, Search, XIcon, CopyIcon, ShuffleIcon, SparklesIcon, PenIcon, LoaderIcon, ShieldAlertIcon } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { applyCounterfactualTestAction } from "@/actions/applyCounterfactualTest"
 import { Slider } from "@/components/ui/slider"
 import { VariationFormData } from "./SimilarPersonaDialog"
 import { mapToDiscrete } from "./variationMapping"
@@ -58,6 +59,28 @@ export function PersonaDetailSheet({
     })
     const [variationLevel, setVariationLevel] = React.useState(2)
     const [selectedCount, setSelectedCount] = React.useState<1 | 3 | 5>(3)
+    const [counterfactualResults, setCounterfactualResults] = React.useState<{ detail: string; reason: string; attribute?: string }[] | null>(null)
+    const [isRunningCounterfactual, setIsRunningCounterfactual] = React.useState(false)
+
+    const handleCounterfactual = React.useCallback(async () => {
+        if (!persona) return
+        setIsRunningCounterfactual(true)
+        try {
+            const result = await applyCounterfactualTestAction(persona)
+            setCounterfactualResults(result)
+        } catch {
+            setCounterfactualResults([{ detail: "Test failed", reason: "Unable to run counterfactual test", attribute: "error" }])
+        } finally {
+            setIsRunningCounterfactual(false)
+        }
+    }, [persona])
+
+    const attrOpacity = (tier?: string, confidence?: number): number => {
+        if (!tier || tier === 'observed') return 1
+        if (tier === 'interpreted') return confidence && confidence < 0.7 ? 0.6 : 0.8
+        if (tier === 'synthetic') return 0.5
+        return 1
+    }
 
     React.useEffect(() => {
         if (persona) {
@@ -244,6 +267,11 @@ export function PersonaDetailSheet({
                             <div className="flex flex-col min-w-0">
                                 <h2 className="text-base font-semibold tracking-tight truncate">{persona.name}</h2>
                                 <p className="text-xs text-muted-foreground truncate">{persona.occupation}</p>
+                                {persona.generationMode && (
+                                    <span className="text-[10px] font-medium text-primary/70 mt-0.5">
+                                        {persona.generationMode === 'research' ? 'Transcript-based' : persona.generationMode === 'cluster' ? 'Synthesized from interviews' : 'Description-based'}
+                                    </span>
+                                )}
                             </div>
                         </div>
                         <div className="flex items-center gap-1 ml-4 shrink-0">
@@ -300,6 +328,17 @@ export function PersonaDetailSheet({
                                     {isEditing ? "Editing" : "Edit"}
                                 </button>
                             )}
+                            {persona.generationMode === 'strategy' && (
+                                <button
+                                    onClick={handleCounterfactual}
+                                    disabled={isRunningCounterfactual}
+                                    className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/30 transition-colors"
+                                    title="Check for risky synthetic details"
+                                >
+                                    <ShieldAlertIcon className="w-3.5 h-3.5" />
+                                    {isRunningCounterfactual ? "Checking..." : "Check"}
+                                </button>
+                            )}
                             <div className="w-px h-5 bg-border/40 mx-1" />
                             <button
                                 onClick={onClose}
@@ -329,6 +368,27 @@ export function PersonaDetailSheet({
                                         </>
                                     )}
                                 </div>
+
+                                {/* Counterfactual Results */}
+                                {counterfactualResults && counterfactualResults.length > 0 && (
+                                    <div className="flex flex-col gap-2 rounded-lg border border-amber-200 bg-amber-50/50 p-3">
+                                        <h4 className="text-xs font-bold text-amber-700 uppercase tracking-widest">⚠ Assumptions to Review</h4>
+                                        <p className="text-xs text-amber-600/80">These details could change product decisions if incorrect:</p>
+                                        <ul className="space-y-1.5">
+                                            {counterfactualResults.map((r, i) => (
+                                                <li key={i} className="text-xs text-amber-700 flex gap-2">
+                                                    <span className="font-medium shrink-0">{r.attribute}:</span>
+                                                    <span>{r.detail} — {r.reason}</span>
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    </div>
+                                )}
+                                {counterfactualResults && counterfactualResults.length === 0 && (
+                                    <div className="flex flex-col gap-1 rounded-lg border border-green-200 bg-green-50/50 p-3">
+                                        <p className="text-xs font-medium text-green-700">✓ All synthetic details pass counterfactual test</p>
+                                    </div>
+                                )}
 
                                 {/* Backstory */}
                                 <div className="flex flex-col gap-3">
@@ -373,17 +433,47 @@ export function PersonaDetailSheet({
                                     </div>
                                 )}
 
-                                {/* Big Five */}
-                                <div className="flex flex-col gap-4">
-                                    <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">BIG FIVE TRAITS</h4>
-                                    <div className="space-y-4">
+                                {/* Behavioral Dimensions */}
+                                {persona.behavioralDimensions && persona.behavioralDimensions.length > 0 && (
+                                    <div className="flex flex-col gap-3">
+                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">BEHAVIOR MODEL</h4>
+                                        <div className="space-y-3">
+                                            {persona.behavioralDimensions.map((dim, i) => (
+                                                <div key={i} className="flex flex-col gap-1.5" style={{ opacity: attrOpacity(dim.evidence ? 'observed' : undefined) }}>
+                                                    <div className="flex justify-between items-end">
+                                                        <span className="text-xs font-medium text-foreground">{dim.name}</span>
+                                                        <span className="text-xs font-mono text-muted-foreground">{dim.score}/100</span>
+                                                    </div>
+                                                    <Progress value={dim.score} className="h-1.5" />
+                                                    <div className="flex justify-between text-[11px] text-muted-foreground/60">
+                                                        <span>{dim.context}</span>
+                                                        {dim.evidence && (
+                                                            <span className="text-primary/60 flex items-center gap-1" title={dim.evidence}>
+                                                                ● observed
+                                                            </span>
+                                                        )}
+                                                    </div>
+                                                    <p className="text-xs text-muted-foreground/80">{dim.description}</p>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+
+                                {/* Big Five (demoted) */}
+                                <details className="flex flex-col gap-4 group">
+                                    <summary className="text-xs font-bold text-muted-foreground uppercase tracking-widest cursor-pointer hover:text-foreground transition-colors list-none flex items-center gap-2">
+                                        <span className="text-[10px] text-muted-foreground/40 group-open:rotate-90 transition-transform">▶</span>
+                                        PERSONALITY TRAITS (BIG FIVE)
+                                    </summary>
+                                    <div className="space-y-4 pt-2">
                                         {renderScalar("Conscientiousness", persona.conscientiousness, "Chaotic", "Meticulous")}
                                         {renderScalar("Neuroticism", persona.neuroticism, "Stable", "Anxious")}
                                         {renderScalar("Openness", persona.openness, "Traditional", "Curious")}
                                         {renderScalar("Extraversion", persona.extraversion, "Introvert", "Extrovert")}
                                         {renderScalar("Agreeableness", persona.agreeableness, "Competitive", "Compassionate")}
                                     </div>
-                                </div>
+                                </details>
 
                                 {/* Psychographic */}
                                 <div className="flex flex-col gap-4">
@@ -418,6 +508,59 @@ export function PersonaDetailSheet({
                                         </div>
                                     )}
                                 </div>
+
+                                {/* Identity vs Situation Context */}
+                                {(persona.identityContext || persona.situationContext) && (
+                                    <div className="flex flex-col gap-3">
+                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">CONTEXT</h4>
+                                        {persona.identityContext && (
+                                            <div className="flex flex-col gap-1">
+                                                <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Stable traits</span>
+                                                <p className="text-sm text-foreground/80">{persona.identityContext}</p>
+                                            </div>
+                                        )}
+                                        {persona.situationContext && (
+                                            <div className="flex flex-col gap-1">
+                                                <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Situational behavior</span>
+                                                <p className="text-sm text-foreground/80">{persona.situationContext}</p>
+                                            </div>
+                                        )}
+                                    </div>
+                                )}
+
+                                {/* Evidence Links */}
+                                {persona.evidenceLinks && persona.evidenceLinks.length > 0 && (
+                                    <details className="flex flex-col gap-3 group">
+                                        <summary className="text-xs font-bold text-muted-foreground uppercase tracking-widest cursor-pointer hover:text-foreground transition-colors list-none flex items-center gap-2">
+                                            <span className="text-[10px] text-muted-foreground/40 group-open:rotate-90 transition-transform">▶</span>
+                                            SOURCE EVIDENCE ({persona.evidenceLinks.length})
+                                        </summary>
+                                        <div className="space-y-2 pt-2">
+                                            {persona.evidenceLinks.map((link, i) => (
+                                                <div key={i} className="flex flex-col gap-1 rounded-lg border border-border/40 bg-secondary/20 p-3">
+                                                    <span className="text-xs font-medium text-foreground">{link.attribute}</span>
+                                                    <p className="text-xs text-muted-foreground/80 italic">"{link.excerpt}"</p>
+                                                    <span className="text-[10px] text-muted-foreground/60">{link.transcriptId}</span>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </details>
+                                )}
+
+                                {/* Cluster Info */}
+                                {persona.clusterInfo && (
+                                    <div className="flex flex-col gap-2 rounded-lg border border-border/40 bg-secondary/20 p-3">
+                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">CLUSTER</h4>
+                                        <p className="text-xs text-muted-foreground/80">
+                                            Represents {persona.clusterInfo.representedCount} interview subjects
+                                        </p>
+                                        {persona.clusterInfo.sourceIds.length > 0 && (
+                                            <p className="text-xs text-muted-foreground/60">
+                                                Sources: {persona.clusterInfo.sourceIds.join(", ")}
+                                            </p>
+                                        )}
+                                    </div>
+                                )}
                             </div>
                         </ScrollArea>
                     )}

--- a/src/components/custom/PersonaDetailSheet.tsx
+++ b/src/components/custom/PersonaDetailSheet.tsx
@@ -65,6 +65,7 @@ export function PersonaDetailSheet({
     const handleCounterfactual = React.useCallback(async () => {
         if (!persona) return
         setIsRunningCounterfactual(true)
+        setCounterfactualResults(null)
         try {
             const result = await applyCounterfactualTestAction(persona)
             setCounterfactualResults(result)
@@ -75,15 +76,9 @@ export function PersonaDetailSheet({
         }
     }, [persona])
 
-    const attrOpacity = (tier?: string, confidence?: number): number => {
-        if (!tier || tier === 'observed') return 1
-        if (tier === 'interpreted') return confidence && confidence < 0.7 ? 0.6 : 0.8
-        if (tier === 'synthetic') return 0.5
-        return 1
-    }
-
     React.useEffect(() => {
         if (persona) {
+            setCounterfactualResults(null)
             setBigFive({
                 conscientiousness: mapToDiscrete(persona.conscientiousness),
                 neuroticism: mapToDiscrete(persona.neuroticism),

--- a/src/components/custom/PersonaDetailSheet.tsx
+++ b/src/components/custom/PersonaDetailSheet.tsx
@@ -470,7 +470,11 @@ export function PersonaDetailSheet({
                                     {persona.behavioralDimensions && persona.behavioralDimensions.length > 0 ? (
                                         <div className="space-y-2">
                                             {[...persona.behavioralDimensions]
-                                                .sort((a, b) => b.score - a.score)
+                                                .sort((a, b) => {
+                                                    const aProv = persona.provenance?.attributes?.find(pa => pa.attribute === a.name)
+                                                    const bProv = persona.provenance?.attributes?.find(pa => pa.attribute === b.name)
+                                                    return (bProv?.confidence ?? 0) - (aProv?.confidence ?? 0)
+                                                })
                                                 .map((dim, i) => {
                                                     const label = dim.score >= 80 ? 'Very High' : dim.score >= 60 ? 'High' : dim.score >= 40 ? 'Moderate' : dim.score >= 20 ? 'Low' : 'Very Low'
                                                     const labelColor = dim.score >= 80 ? 'text-green-600' : dim.score >= 60 ? 'text-emerald-500' : dim.score >= 40 ? 'text-amber-500' : 'text-gray-400'

--- a/src/components/custom/PersonaDetailSheet.tsx
+++ b/src/components/custom/PersonaDetailSheet.tsx
@@ -376,257 +376,238 @@ export function PersonaDetailSheet({
                                     </div>
                                 )}
 
-                                {/* 1. Behavior Summary */}
-                                <div className="flex flex-col gap-2">
-                                    <div className="flex items-center gap-2">
+{/* TIER 1 */}
+
+                                <div className="flex flex-col gap-8 mt-8">
+
+                                <div className="flex flex-col gap-3">
+                                    <div className="flex items-center gap-3">
                                         <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">BEHAVIOR SUMMARY</h4>
                                         {persona.provenance && (
-                                            <span className="text-[10px] text-muted-foreground/50 bg-secondary/40 px-1.5 py-0.5 rounded-sm">
-                                                {Math.round(persona.provenance.overallConfidence * 100)}% confidence
+                                            <span className="inline-flex items-center gap-1.5 text-[10px] font-medium text-muted-foreground bg-secondary/40 border border-border/30 rounded-full px-2.5 py-0.5">
+                                                <span className="w-1 h-1 rounded-full bg-primary/60" />
+                                                {Math.round(persona.provenance.overallConfidence * 100)}%
                                             </span>
                                         )}
                                     </div>
                                     {persona.backstory ? (
-                                        <p className="text-xs text-foreground/80 leading-relaxed">
-                                            {persona.backstory.split('\n\n')[0]}
-                                        </p>
+                                        <p className="text-xs text-foreground/80 leading-relaxed max-w-prose">{persona.backstory.split('\n\n')[0]}</p>
                                     ) : (
                                         <p className="text-xs text-muted-foreground/60 italic">No summary available</p>
                                     )}
                                 </div>
 
-                                {/* Best For / Less Reliable For */}
                                 {(persona.bestFor || persona.lessReliableFor) && (
-                                    <div className="flex flex-col gap-2">
+                                    <div className="flex flex-col gap-3">
                                         <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">PREDICTION SCOPE</h4>
                                         {persona.bestFor && persona.bestFor.length > 0 && (
-                                            <div className="flex flex-col gap-1">
-                                                <span className="text-[11px] font-medium text-green-700">Best for</span>
-                                                <div className="flex flex-wrap gap-1.5">
-                                                    {persona.bestFor.map((item, i) => (
-                                                        <span key={i} className="inline-flex items-center gap-1 text-[11px] bg-green-50 text-green-700 border border-green-200 px-2 py-0.5 rounded-sm">
-                                                            ✓ {item}
-                                                        </span>
-                                                    ))}
-                                                </div>
+                                            <div className="flex flex-wrap gap-2">
+                                                {persona.bestFor!.map((item, i) => (
+                                                    <span key={i} className="inline-flex items-center text-[11px] font-medium text-emerald-600 bg-emerald-50 border border-emerald-200 rounded-full px-3 py-1">{item}</span>
+                                                ))}
                                             </div>
                                         )}
                                         {persona.lessReliableFor && persona.lessReliableFor.length > 0 && (
-                                            <div className="flex flex-col gap-1 mt-1">
-                                                <span className="text-[11px] font-medium text-amber-600">Less reliable for</span>
-                                                <div className="flex flex-wrap gap-1.5">
-                                                    {persona.lessReliableFor.map((item, i) => (
-                                                        <span key={i} className="inline-flex items-center gap-1 text-[11px] bg-amber-50 text-amber-700 border border-amber-200 px-2 py-0.5 rounded-sm">
-                                                            △ {item}
-                                                        </span>
-                                                    ))}
-                                                </div>
+                                            <div className="flex flex-wrap gap-2">
+                                                {persona.lessReliableFor!.map((item, i) => (
+                                                    <span key={i} className="inline-flex items-center text-[11px] font-medium text-amber-600 bg-amber-50 border border-amber-200 rounded-full px-3 py-1">{item}</span>
+                                                ))}
                                             </div>
                                         )}
                                     </div>
                                 )}
 
-                                {/* 2. Decision Model */}
-                                <div className="flex flex-col gap-2">
-                                    <div className="flex items-center gap-2">
+                                <div className="flex flex-col gap-3">
+                                    <div className="flex items-center gap-3">
                                         <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">DECISION MODEL</h4>
                                         {persona.provenance && (
-                                            <span className="text-[10px] text-muted-foreground/50 bg-secondary/40 px-1.5 py-0.5 rounded-sm">
-                                                {Math.round(persona.provenance.overallConfidence * 100)}% confidence
+                                            <span className="inline-flex items-center gap-1.5 text-[10px] font-medium text-muted-foreground bg-secondary/40 border border-border/30 rounded-full px-2.5 py-0.5">
+                                                <span className="w-1 h-1 rounded-full bg-primary/60" />
+                                                {Math.round(persona.provenance.overallConfidence * 100)}%
                                             </span>
                                         )}
                                     </div>
-                                    {persona.decisionStyle && (
-                                        <p className="text-xs text-foreground/80">
-                                            <span className="text-muted-foreground">Style:</span> {persona.decisionStyle}
-                                        </p>
-                                    )}
-                                    <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground/80">
+                                    {persona.decisionStyle && <p className="text-xs text-foreground/80"><span className="text-muted-foreground">Style:</span> {persona.decisionStyle}</p>}
+                                    <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground/80">
                                         <span>Price sensitivity: {persona.pricingSensitivity}/100</span>
-                                        {persona.typicalBudget && <span>· {persona.typicalBudget}</span>}
+                                        {persona.typicalBudget && <span className="text-muted-foreground/40">/</span>}
+                                        {persona.typicalBudget && <span>{persona.typicalBudget}</span>}
                                     </div>
                                     {persona.goals.length > 0 && (
-                                        <div className="flex flex-col gap-1 mt-1">
-                                            <span className="text-[11px] font-medium text-green-700">Likely to adopt if helps with:</span>
-                                            <div className="flex flex-wrap gap-1.5">
+                                        <div className="flex flex-col gap-1.5 mt-1">
+                                            <span className="text-[11px] font-medium text-emerald-600">Likely to adopt if helps with</span>
+                                            <div className="flex flex-wrap gap-x-3 gap-y-1">
                                                 {persona.goals.slice(0, 4).map((g, i) => (
-                                                    <span key={i} className="text-xs text-green-700/80">✓ {g}</span>
+                                                    <span key={i} className="text-xs text-emerald-600/80">{g}</span>
                                                 ))}
                                             </div>
                                         </div>
                                     )}
                                 </div>
 
-                                {/* 3. Behavior Patterns (sorted by confidence descending) */}
                                 <div className="flex flex-col gap-3">
-                                    <div className="flex items-center gap-2">
+                                    <div className="flex items-center gap-3">
                                         <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">BEHAVIOR PATTERNS</h4>
                                         {persona.provenance && (
-                                            <span className="text-[10px] text-muted-foreground/50 bg-secondary/40 px-1.5 py-0.5 rounded-sm">
-                                                {Math.round(persona.provenance.overallConfidence * 100)}% confidence
+                                            <span className="inline-flex items-center gap-1.5 text-[10px] font-medium text-muted-foreground bg-secondary/40 border border-border/30 rounded-full px-2.5 py-0.5">
+                                                <span className="w-1 h-1 rounded-full bg-primary/60" />
+                                                {Math.round(persona.provenance.overallConfidence * 100)}%
                                             </span>
                                         )}
                                     </div>
                                     {persona.behavioralDimensions && persona.behavioralDimensions.length > 0 ? (
-                                        <div className="space-y-2">
-                                            {[...persona.behavioralDimensions]
-                                                .sort((a, b) => {
-                                                    const aProv = persona.provenance?.attributes?.find(pa => pa.attribute === a.name)
-                                                    const bProv = persona.provenance?.attributes?.find(pa => pa.attribute === b.name)
-                                                    return (bProv?.confidence ?? 0) - (aProv?.confidence ?? 0)
-                                                })
-                                                .map((dim, i) => {
-                                                    const label = dim.score >= 80 ? 'Very High' : dim.score >= 60 ? 'High' : dim.score >= 40 ? 'Moderate' : dim.score >= 20 ? 'Low' : 'Very Low'
-                                                    const labelColor = dim.score >= 80 ? 'text-green-600' : dim.score >= 60 ? 'text-emerald-500' : dim.score >= 40 ? 'text-amber-500' : 'text-gray-400'
-                                                    return (
-                                                        <div key={i} className="flex items-start gap-3 py-1.5 border-b border-border/10 last:border-0">
-                                                            <div className="flex-1 min-w-0">
-                                                                <div className="flex items-center gap-2">
-                                                                    <span className="text-xs font-medium text-foreground">{dim.name}</span>
-                                                                    <span className={`text-[10px] font-medium ${labelColor}`}>{label}</span>
-                                                                </div>
-                                                                <p className="text-[11px] text-muted-foreground/70 mt-0.5">{dim.description}</p>
+                                        <div className="flex flex-col">
+                                            {[...persona.behavioralDimensions].sort((a, b) => {
+                                                const ap = persona.provenance?.attributes?.find(pa => pa.attribute === a.name);
+                                                const bp = persona.provenance?.attributes?.find(pa => pa.attribute === b.name);
+                                                return (bp?.confidence ?? 0) - (ap?.confidence ?? 0);
+                                            }).map((dim, i) => {
+                                                const label = dim.score >= 80 ? 'Very High' : dim.score >= 60 ? 'High' : dim.score >= 40 ? 'Moderate' : dim.score >= 20 ? 'Low' : 'Very Low';
+                                                const lc = dim.score >= 80 ? 'text-emerald-600' : dim.score >= 60 ? 'text-sky-600' : dim.score >= 40 ? 'text-amber-600' : 'text-gray-400';
+                                                return (
+                                                    <div key={i} className="flex items-start gap-3 py-3 border-b border-border/10 last:border-0">
+                                                        <div className="flex-1 min-w-0">
+                                                            <div className="flex items-center gap-2.5">
+                                                                <span className="text-xs font-medium text-foreground">{dim.name}</span>
+                                                                <span className={'text-[10px] font-medium ' + lc}>{label}</span>
                                                             </div>
-                                                            {dim.evidence && (
-                                                                <div className="group relative shrink-0">
-                                                                    <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-primary/10 text-primary cursor-help text-[10px] font-bold">?</span>
-                                                                    <div className="absolute right-0 top-full mt-1 w-56 p-2 rounded-lg border border-border bg-card shadow-lg text-[11px] text-foreground/80 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-50">
-                                                                        {dim.evidence}
-                                                                    </div>
-                                                                </div>
-                                                            )}
+                                                            <p className="text-[11px] text-muted-foreground/60 mt-1 leading-relaxed">{dim.description}</p>
                                                         </div>
-                                                    )
-                                                })}
+                                                        {dim.evidence && (
+                                                            <div className="group relative shrink-0 mt-0.5">
+                                                                <span className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-secondary/60 text-muted-foreground/50 cursor-help text-[9px] font-bold">?</span>
+                                                                <div className="absolute right-0 top-full mt-1.5 w-60 p-2.5 rounded-lg border border-border bg-card text-[11px] text-foreground/80 leading-relaxed opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-50 pointer-events-none">
+                                                                    {dim.evidence}
+                                                                </div>
+                                                            </div>
+                                                        )}
+                                                    </div>
+                                                );
+                                            })}
                                         </div>
-                                    ) : (
-                                        <div className="flex flex-col gap-1.5">
-                                            {persona.goals.slice(0, 4).map((goal, i) => (
-                                                <div key={i} className="flex items-center gap-2 text-xs text-foreground/80">
-                                                    <span className="text-primary shrink-0">✓</span>
-                                                    {goal}
-                                                </div>
-                                            ))}
-                                        </div>
-                                    )}
+                                    ) : null}
+                                </div>
                                 </div>
 
-                                {/* 4. Motivations */}
+                                {/* TIER 2 */}
+                                <div className="flex flex-col gap-6 mt-8">
+
                                 {persona.values && persona.values.length > 0 && (
-                                    <div className="flex flex-col gap-2">
-                                        <div className="flex items-center gap-2">
+                                    <div className="flex flex-col gap-3">
+                                        <div className="flex items-center gap-3">
                                             <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">MOTIVATIONS</h4>
                                             {persona.provenance && (
-                                                <span className="text-[10px] text-muted-foreground/50 bg-secondary/40 px-1.5 py-0.5 rounded-sm">
-                                                    {Math.round(persona.provenance.overallConfidence * 100)}% confidence
+                                                <span className="inline-flex items-center gap-1.5 text-[10px] font-medium text-muted-foreground bg-secondary/40 border border-border/30 rounded-full px-2.5 py-0.5">
+                                                    <span className="w-1 h-1 rounded-full bg-primary/60" />
+                                                    {Math.round(persona.provenance.overallConfidence * 100)}%
                                                 </span>
                                             )}
                                         </div>
-                                        <div className="flex flex-wrap gap-1.5">
+                                        <div className="flex flex-wrap gap-2">
                                             {persona.values.map((v, i) => (
-                                                <span key={i} className="inline-flex items-center gap-1.5 text-xs font-medium bg-primary/10 text-primary px-2.5 py-1 rounded-sm">
-                                                    <span className="w-1.5 h-1.5 rounded-full bg-primary" />
-                                                    {v}
-                                                </span>
+                                                <span key={i} className="inline-flex items-center text-xs font-medium text-foreground bg-secondary/50 border border-border/30 rounded-full px-3 py-1">{v}</span>
                                             ))}
                                         </div>
                                     </div>
                                 )}
 
-                                {/* 5. Frictions */}
                                 {persona.fears && persona.fears.length > 0 && (
-                                    <div className="flex flex-col gap-2">
-                                        <div className="flex items-center gap-2">
+                                    <div className="flex flex-col gap-3">
+                                        <div className="flex items-center gap-3">
                                             <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">FRICTIONS</h4>
                                             {persona.provenance && (
-                                                <span className="text-[10px] text-muted-foreground/50 bg-secondary/40 px-1.5 py-0.5 rounded-sm">
-                                                    {Math.round(persona.provenance.overallConfidence * 100)}% confidence
+                                                <span className="inline-flex items-center gap-1.5 text-[10px] font-medium text-muted-foreground bg-secondary/40 border border-border/30 rounded-full px-2.5 py-0.5">
+                                                    <span className="w-1 h-1 rounded-full bg-primary/60" />
+                                                    {Math.round(persona.provenance.overallConfidence * 100)}%
                                                 </span>
                                             )}
                                         </div>
-                                        <ul className="space-y-1.5">
+                                        <ul className="space-y-2">
                                             {persona.fears.map((f, i) => (
-                                                <li key={i} className="text-xs text-foreground/80 flex gap-2 leading-relaxed">
-                                                    <span className="text-destructive shrink-0 mt-0.5">✕</span>
+                                                <li key={i} className="text-xs text-foreground/70 flex gap-2.5 leading-relaxed">
+                                                    <span className="text-destructive/60 shrink-0 mt-0.5">/</span>
                                                     {f}
                                                 </li>
                                             ))}
                                         </ul>
                                     </div>
                                 )}
+                                </div>
 
-                                {/* 6. Evidence & Confidence */}
+                                {/* TIER 3 */}
+                                <div className="flex flex-col gap-5 mt-6 border-t border-border/10 pt-6">
+
                                 <div className="flex flex-col gap-3">
                                     <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">EVIDENCE &amp; CONFIDENCE</h4>
                                     {persona.provenance ? (
                                         <>
-                                            <div className="flex items-center gap-2 text-xs text-foreground/80">
-                                                <span>Overall:</span>
-                                                <div className="flex-1 h-1.5 max-w-[100px] rounded-full bg-secondary">
-                                                    <div className="h-full rounded-full bg-primary" style={{ width: `${persona.provenance.overallConfidence * 100}%` }} />
+                                            <div className="flex items-center gap-3 text-xs">
+                                                <span className="text-muted-foreground">Overall</span>
+                                                <div className="flex-1 h-1 max-w-[80px] rounded-full bg-secondary">
+                                                    <div className="h-full rounded-full bg-primary" style={{ width: persona.provenance.overallConfidence * 100 + '%' }} />
                                                 </div>
-                                                <span className="font-mono text-muted-foreground text-[11px]">{Math.round(persona.provenance.overallConfidence * 100)}%</span>
+                                                <span className="font-mono text-muted-foreground/60 text-[11px]">{Math.round(persona.provenance.overallConfidence * 100)}%</span>
                                             </div>
                                             {persona.provenance.attributes.length > 0 && (
-                                                <div className="flex flex-wrap gap-1.5">
-                                                    {persona.provenance.attributes.map((attr, i) => (
-                                                        <div key={i} className="group relative inline-flex items-center gap-1.5 text-[10px] bg-secondary/30 border border-border/30 rounded-sm px-1.5 py-1">
-                                                            <span className={`w-1.5 h-1.5 rounded-full ${attr.tier === 'observed' ? 'bg-green-500' : attr.tier === 'interpreted' ? 'bg-amber-400' : 'bg-gray-300'}`} />
-                                                            <span className="text-muted-foreground">{attr.attribute}</span>
-                                                            {attr.confidence < 1 && (
-                                                                <span className="text-muted-foreground/50">{Math.round(attr.confidence * 100)}%</span>
-                                                            )}
-                                                            {attr.evidence && (
-                                                                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 w-48 p-2 rounded-lg border border-border bg-card shadow-lg text-[11px] text-foreground/80 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-50 pointer-events-none">
-                                                                    {attr.evidence}
+                                                <div className="grid grid-cols-2 gap-x-4 gap-y-2 mt-1">
+                                                    {persona.provenance.attributes.map((attr, i) => {
+                                                        const tc = attr.tier === 'observed' ? 'bg-emerald-500' : attr.tier === 'interpreted' ? 'bg-amber-400' : 'bg-gray-400';
+                                                        return (
+                                                            <div key={i} className="group relative flex items-center gap-2.5 text-xs">
+                                                                <span className={'w-1.5 h-1.5 rounded-full shrink-0 ' + tc} />
+                                                                <div className="flex-1 min-w-0 flex items-center gap-2">
+                                                                    <span className="text-foreground/70 truncate">{attr.attribute}</span>
+                                                                    <span className="text-muted-foreground/40 text-[10px] font-mono">{Math.round(attr.confidence * 100)}%</span>
                                                                 </div>
-                                                            )}
-                                                        </div>
-                                                    ))}
+                                                                {attr.evidence && (
+                                                                    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 w-56 p-2.5 rounded-lg border border-border bg-card text-[11px] text-foreground/80 leading-relaxed opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-50 pointer-events-none">
+                                                                        {attr.evidence}
+                                                                    </div>
+                                                                )}
+                                                            </div>
+                                                        );
+                                                    })}
                                                 </div>
                                             )}
                                         </>
                                     ) : (
                                         <p className="text-xs text-muted-foreground/60">
-                                            {persona.generationMode === 'research'
-                                                ? "No provenance data available"
-                                                : "Generated from a description. Not linked to interview sources."
-                                            }
+                                            {persona.generationMode === 'research' ? "No provenance data available" : "Generated from a description."}
                                         </p>
                                     )}
                                 </div>
 
-                                {/* 7. Sources */}
                                 {persona.evidenceLinks && persona.evidenceLinks.length > 0 && (
-                                    <div className="flex flex-col gap-2">
+                                    <div className="flex flex-col gap-3">
                                         <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">SOURCES</h4>
-                                        <div className="space-y-2">
+                                        <div className="flex flex-col gap-2">
                                             {persona.evidenceLinks.map((link, i) => (
-                                                <div key={i} className="flex flex-col gap-1 rounded-lg border border-border/40 bg-secondary/20 p-3">
-                                                    <div className="flex items-center gap-2">
-                                                        <span className="text-[10px] font-medium text-muted-foreground uppercase">{link.attribute}</span>
-                                                        <span className="text-[10px] text-muted-foreground/50">{link.transcriptId}</span>
+                                                <div key={i} className="relative pl-4 border-l-2 border-border/40">
+                                                    <div className="flex items-center gap-2 mb-1">
+                                                        <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">{link.attribute}</span>
+                                                        <span className="text-[10px] text-muted-foreground/40">{link.transcriptId}</span>
                                                     </div>
-                                                    <p className="text-xs text-foreground/80 italic leading-relaxed">"{link.excerpt}"</p>
+                                                    <p className="text-xs text-foreground/70 italic leading-relaxed">{link.excerpt}</p>
                                                 </div>
                                             ))}
                                         </div>
                                     </div>
                                 )}
+                                </div>
 
-                                {/* 8. Additional Context (collapsible) */}
-                                <details className="flex flex-col gap-3 group border-t border-border/10 pt-3">
-                                    <summary className="text-xs font-bold text-muted-foreground uppercase tracking-widest cursor-pointer hover:text-foreground transition-colors list-none flex items-center gap-2">
-                                        <span className="text-[10px] text-muted-foreground/30 group-open:rotate-90 transition-transform">▶</span>
+                                <div className="flex flex-col gap-3 mt-6 border-t border-border/10 pt-6">
+
+                                <details className="group">
+                                    <summary className="text-xs font-bold text-muted-foreground uppercase tracking-widest cursor-pointer hover:text-foreground transition-colors list-none flex items-center gap-2 py-1">
+                                        <span className="text-[10px] text-muted-foreground/30 group-open:rotate-90 transition-transform duration-150">{'▶'}</span>
                                         ADDITIONAL CONTEXT
                                     </summary>
-                                    <div className="flex flex-col gap-4 pt-3">
+                                    <div className="flex flex-col gap-4 pt-4 pb-2">
                                         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
                                             {persona.age && <span>{persona.age} years old</span>}
                                             {persona.educationLevel && <><span className="w-1 h-1 rounded-full bg-border" /><span>{persona.educationLevel}</span></>}
                                             {persona.occupation && <><span className="w-1 h-1 rounded-full bg-border" /><span>{persona.occupation}</span></>}
                                         </div>
-
                                         {persona.backstory && (
                                             <div className="flex flex-col gap-2">
                                                 <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">BACKSTORY</h4>
@@ -636,37 +617,34 @@ export function PersonaDetailSheet({
                                                 </div>
                                                 <div className="flex flex-col gap-3 max-h-[200px] overflow-y-auto custom-scrollbar pr-1">
                                                     {filteredBackstory.map((paragraph, i) => (
-                                                        <p key={`${persona.id}-para-${i}`} className={cn("text-sm leading-relaxed text-foreground/70",
+                                                        <p key={persona.id + '-para-' + i} className={cn("text-sm leading-relaxed text-foreground/70",
                                                             searchTerm && paragraph.toLowerCase().includes(searchTerm.toLowerCase()) ? "bg-primary/5 rounded-lg p-2" : ""
                                                         )}>{paragraph}</p>
                                                     ))}
                                                 </div>
                                             </div>
                                         )}
-
                                         {(persona.identityContext || persona.situationContext) && (
                                             <div className="flex flex-col gap-2">
-                                                {persona.identityContext && <p className="text-xs text-foreground/70"><span className="text-muted-foreground">Stable:</span> {persona.identityContext}</p>}
-                                                {persona.situationContext && <p className="text-xs text-foreground/70"><span className="text-muted-foreground">Context:</span> {persona.situationContext}</p>}
+                                                {persona.identityContext && <p className="text-xs text-foreground/70"><span className="text-muted-foreground">Stable</span> {persona.identityContext}</p>}
+                                                {persona.situationContext && <p className="text-xs text-foreground/70"><span className="text-muted-foreground">Context</span> {persona.situationContext}</p>}
                                             </div>
                                         )}
-
                                         {persona.clusterInfo && (
                                             <div className="text-xs text-muted-foreground/70">
                                                 Represents {persona.clusterInfo.representedCount} interview subjects
-                                                {persona.clusterInfo.sourceIds.length > 0 && ` (${persona.clusterInfo.sourceIds.join(", ")})`}
+                                                {persona.clusterInfo.sourceIds.length > 0 && (' (' + persona.clusterInfo.sourceIds.join(', ') + ')')}
                                             </div>
                                         )}
                                     </div>
                                 </details>
 
-                                {/* 9. Advanced Model Details (collapsible) */}
-                                <details className="flex flex-col gap-3 group">
-                                    <summary className="text-xs font-bold text-muted-foreground uppercase tracking-widest cursor-pointer hover:text-foreground transition-colors list-none flex items-center gap-2">
-                                        <span className="text-[10px] text-muted-foreground/30 group-open:rotate-90 transition-transform">▶</span>
+                                <details className="group">
+                                    <summary className="text-xs font-bold text-muted-foreground uppercase tracking-widest cursor-pointer hover:text-foreground transition-colors list-none flex items-center gap-2 py-1">
+                                        <span className="text-[10px] text-muted-foreground/30 group-open:rotate-90 transition-transform duration-150">{'▶'}</span>
                                         ADVANCED MODEL DETAILS
                                     </summary>
-                                    <div className="flex flex-col gap-5 pt-3">
+                                    <div className="flex flex-col gap-5 pt-4 pb-2">
                                         <div className="space-y-4">
                                             {renderScalar("Conscientiousness", persona.conscientiousness, "Chaotic", "Meticulous")}
                                             {renderScalar("Neuroticism", persona.neuroticism, "Stable", "Anxious")}
@@ -674,9 +652,7 @@ export function PersonaDetailSheet({
                                             {renderScalar("Extraversion", persona.extraversion, "Introvert", "Extrovert")}
                                             {renderScalar("Agreeableness", persona.agreeableness, "Competitive", "Compassionate")}
                                         </div>
-                                        {persona.communicationStyle && (
-                                            <p className="text-xs text-foreground/70">Communication: {persona.communicationStyle}</p>
-                                        )}
+                                        {persona.communicationStyle && <p className="text-xs text-foreground/70">Communication: {persona.communicationStyle}</p>}
                                         {persona.interests && persona.interests.length > 0 && (
                                             <div className="flex flex-wrap gap-1.5">
                                                 {persona.interests.map((v, i) => (
@@ -684,21 +660,18 @@ export function PersonaDetailSheet({
                                                 ))}
                                             </div>
                                         )}
-                                        {/* PB&J Rationales */}
                                         {persona.pbjRationales && (
                                             <div className="flex flex-col gap-2 pt-2 border-t border-border/10">
-                                                <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">PSYCHOLOGICAL RATIONALES (PB&J)</h4>
-                                                <div className="text-xs text-foreground/70 leading-relaxed whitespace-pre-wrap max-h-[300px] overflow-y-auto custom-scrollbar">
-                                                    {persona.pbjRationales}
-                                                </div>
+                                                <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">PSYCHOLOGICAL RATIONALES (PB&amp;J)</h4>
+                                                <div className="text-xs text-foreground/70 leading-relaxed whitespace-pre-wrap max-h-[300px] overflow-y-auto custom-scrollbar">{persona.pbjRationales}</div>
                                             </div>
                                         )}
                                     </div>
                                 </details>
+                                </div>
                             </div>
                         </ScrollArea>
                     )}
-
                     {/* Profile Tab — Edit Mode */}
                     {activeTab === "profile" && isEditing && draftPersona && (
                         <ScrollArea className="flex-1 min-h-0">

--- a/src/components/custom/PersonaDetailSheet.tsx
+++ b/src/components/custom/PersonaDetailSheet.tsx
@@ -97,12 +97,12 @@ export function PersonaDetailSheet({
         }
     }, [isOpen, defaultTab])
 
-  React.useEffect(() => {
-    if (persona) {
-      setDraftPersona({ ...persona })
-    }
-    setIsEditing(false)
-  }, [persona?.id])
+    React.useEffect(() => {
+        if (persona) {
+            setDraftPersona({ ...persona })
+        }
+        setIsEditing(false)
+    }, [persona?.id])
 
     const handleStartEdit = React.useCallback(() => {
         if (persona) {
@@ -125,20 +125,20 @@ export function PersonaDetailSheet({
         // Always save the current edits immediately
         onEdit(personaId, editableUpdates)
 
-    if (backstoryChanged && draftPersona.backstory) {
-      setIsSaving(true)
-      setSuggestedTraits(null)
-      setShowSuggestionDialog(true)
-      try {
-        const traits = await regenPersonaTraitsAction(draftPersona.backstory)
-        setSuggestedTraits(traits)
-      } catch (err) {
-        console.warn("[PersonaDetailSheet] Trait regeneration failed:", err)
-        setShowSuggestionDialog(false)
-      } finally {
-        setIsSaving(false)
-      }
-    }
+        if (backstoryChanged && draftPersona.backstory) {
+            setIsSaving(true)
+            setSuggestedTraits(null)
+            setShowSuggestionDialog(true)
+            try {
+                const traits = await regenPersonaTraitsAction(draftPersona.backstory)
+                setSuggestedTraits(traits)
+            } catch (err) {
+                console.warn("[PersonaDetailSheet] Trait regeneration failed:", err)
+                setShowSuggestionDialog(false)
+            } finally {
+                setIsSaving(false)
+            }
+        }
 
         setIsEditing(false)
     }, [draftPersona, onEdit, persona])
@@ -373,7 +373,7 @@ export function PersonaDetailSheet({
 
                                 <div className="flex flex-col gap-3">
                                     <div className="flex items-center gap-3">
-                                            <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">BEHAVIOR PATTERNS</h4>
+                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">BEHAVIOR PATTERNS</h4>
                                     </div>
                                     {persona.behavioralDimensions && persona.behavioralDimensions.length > 0 ? (
                                         <div className="flex flex-col">
@@ -385,13 +385,13 @@ export function PersonaDetailSheet({
                                                 const label = dim.score >= 80 ? 'Very High' : dim.score >= 60 ? 'High' : dim.score >= 40 ? 'Moderate' : dim.score >= 20 ? 'Low' : 'Very Low';
                                                 const lc = dim.score >= 80 ? 'text-emerald-600' : dim.score >= 60 ? 'text-sky-600' : dim.score >= 40 ? 'text-amber-600' : 'text-gray-400';
                                                 return (
-                                                    <div key={i} className="flex flex-col py-3 border-b border-border/10 last:border-0">
+                                                    <div key={i} className="flex flex-col py-5 border-b border-border/10 last:border-0">
                                                         <div className="flex items-center gap-2.5">
                                                             <span className="text-xs font-medium text-foreground">{dim.name}</span>
                                                             <span className={'text-[10px] font-medium ' + lc}>{label}</span>
                                                         </div>
                                                         <p className="text-[11px] text-muted-foreground/60 mt-1 leading-relaxed">{dim.description}</p>
-                                                        {dim.evidence && <details className="mt-1.5 group"><summary className="text-[10px] text-muted-foreground/50 cursor-pointer hover:text-foreground/70 transition-colors list-none flex items-center gap-1.5 font-sans"><span className="text-[10px] leading-none">▶</span> Source</summary><p className="text-[11px] text-foreground/60 italic mt-1.5 leading-relaxed border-l-2 border-border/30 pl-3">{dim.evidence}</p></details>}
+                                                        {dim.evidence && <details className="mt-2 group"><summary className="text-xs text-muted-foreground/60 cursor-pointer hover:text-foreground transition-colors list-none flex items-center gap-1.5 font-sans"><span className="text-xs text-muted-foreground/30 group-open:text-foreground/60 transition-colors">▶</span> Source</summary><p className="text-xs text-foreground/70 mt-1.5 leading-relaxed border-l-2 border-border/30 pl-3">{dim.evidence}</p></details>}
                                                     </div>
                                                 );
                                             })}
@@ -400,217 +400,223 @@ export function PersonaDetailSheet({
                                 </div>
 
 
-                                <div className="flex flex-col gap-3">
+                                <div className="flex flex-col gap-5">
                                     <div className="flex items-center gap-3">
-                                            <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">DECISION MODEL</h4>
+                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">DECISION MODEL</h4>
                                     </div>
-                                    {persona.decisionStyle && <p className="text-xs text-foreground/80"><span className="text-muted-foreground">Style:</span> {persona.decisionStyle}</p>}
-                                    <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground/80">
-                                        <span>Price sensitivity: {persona.pricingSensitivity}/100</span>
-                                        {persona.typicalBudget && <span className="text-muted-foreground/40">/</span>}
-                                        {persona.typicalBudget && <span>{persona.typicalBudget}</span>}
-                                    </div>
-                                    {persona.goals.length > 0 && (
-                                        <div className="flex flex-col gap-1.5 mt-1">
-                                             <span className="text-[11px] font-medium text-muted-foreground">Likely to adopt if helps with</span>
-                                             <div className="flex flex-wrap gap-x-3 gap-y-1">
-                                                 {persona.goals.slice(0, 4).map((g, i) => (
-                                                     <span key={i} className="text-xs text-foreground/80">{g}</span>
-                                                 ))}
-                                             </div>
+                                    <div className="flex flex-col gap-6">
+                                        {persona.decisionStyle && <p className="text-sm text-foreground/80"><span className="text-muted-foreground">Style:</span> {persona.decisionStyle}</p>}
+                                        <div className="flex flex-wrap gap-x-6 gap-y-1.5 text-sm text-muted-foreground/70">
+                                            <span>Price sensitivity: {persona.pricingSensitivity}/100</span>
+                                            {persona.typicalBudget && <span className="text-muted-foreground/40">/</span>}
+                                            {persona.typicalBudget && <span className="text-foreground/80">{persona.typicalBudget}</span>}
                                         </div>
-                                    )}
+                                        {persona.goals.length > 0 && (
+                                            <div className="flex flex-col gap-2">
+                                                <span className="text-xs font-medium text-muted-foreground">Likely to adopt if helps with</span>
+                                                <div className="flex flex-wrap gap-x-4 gap-y-1">
+                                                    {persona.goals.slice(0, 4).map((g, i) => (
+                                                        <span key={i} className="text-sm text-foreground/80">{g}</span>
+                                                    ))}
+                                                </div>
+                                            </div>
+                                        )}
+                                    </div>
                                 </div>
 
 
-                                    {(persona.bestFor?.length || persona.lessReliableFor?.length) ? (
-                                    <div className="flex flex-col gap-3">
+                                {(persona.bestFor?.length || persona.lessReliableFor?.length) ? (
+                                    <div className="flex flex-col gap-6">
                                         <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">PREDICTION SCOPE</h4>
                                         {persona.bestFor && persona.bestFor.length > 0 && (
-                                            <div className="flex flex-wrap gap-2">
-                                                {persona.bestFor!.map((item, i) => (
-                                                    <span key={i} className="inline-flex items-center text-[11px] font-medium text-emerald-600 bg-emerald-50 border border-emerald-200 rounded-full px-3 py-1">{item}</span>
-                                                ))}
+                                            <div className="flex flex-col gap-2">
+                                                <span className="text-xs font-medium text-primary/70">Good for</span>
+                                                <div className="flex flex-wrap gap-x-4 gap-y-1">
+                                                    {persona.bestFor.map((item, i) => (
+                                                        <span key={i} className="text-sm text-foreground/80">{item}</span>
+                                                    ))}
+                                                </div>
                                             </div>
                                         )}
                                         {persona.lessReliableFor && persona.lessReliableFor.length > 0 && (
-                                            <div className="flex flex-wrap gap-2">
-                                                {persona.lessReliableFor!.map((item, i) => (
-                                                    <span key={i} className="inline-flex items-center text-[11px] font-medium text-amber-600 bg-amber-50 border border-amber-200 rounded-full px-3 py-1">{item}</span>
-                                                ))}
+                                            <div className="flex flex-col gap-2">
+                                                <span className="text-xs font-medium text-muted-foreground">Less reliable for</span>
+                                                <div className="flex flex-wrap gap-x-4 gap-y-1">
+                                                    {persona.lessReliableFor.map((item, i) => (
+                                                        <span key={i} className="text-sm text-foreground/80">{item}</span>
+                                                    ))}
+                                                </div>
                                             </div>
                                         )}
                                     </div>
-                                    ) : null}
-                                    
+                                ) : null}
+
                                 {/* TIER 2 */}
                                 <div className="flex flex-col gap-6">
 
-                                {persona.values && persona.values.length > 0 && (
-                                    <div className="flex flex-col gap-3">
-                                        <div className="flex items-center gap-3">
-                                            <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">MOTIVATIONS</h4>
-                                        </div>
-                                        <div className="flex flex-col gap-2">
-                                            <div className="flex flex-wrap gap-2">
+                                    {persona.values && persona.values.length > 0 && (
+                                        <div className="flex flex-col gap-4">
+                                            <div className="flex items-center gap-3">
+                                                <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">MOTIVATIONS</h4>
+                                            </div>
+                                            <div className="flex flex-col gap-5">
                                                 {persona.values.map((v, i) => (
                                                     <div key={i} className="flex flex-col">
-                                                        <span className="inline-flex items-center text-xs font-medium text-foreground bg-secondary/50 border border-border/30 rounded-full px-3 py-1">{v}</span>
-                                                        {persona.valueEvidence?.[i] && <details className="mt-1 group"><summary className="text-[10px] text-muted-foreground/50 cursor-pointer hover:text-foreground/70 transition-colors list-none flex items-center gap-1.5 font-sans pl-1"><span className="text-[10px] leading-none">▶</span> Source</summary><p className="text-[11px] text-foreground/60 italic mt-1 leading-relaxed border-l-2 border-border/30 pl-3 ml-1">{persona.valueEvidence[i]}</p></details>}
+                                                        <span className="text-sm text-foreground/80">{v}</span>
+                                                        {persona.valueEvidence?.[i] && <details className="mt-1.5 group"><summary className="text-xs text-muted-foreground/60 cursor-pointer hover:text-foreground transition-colors list-none flex items-center gap-1.5 font-sans"><span className="text-xs text-muted-foreground/30 group-open:text-foreground/60 transition-colors">▶</span> Source</summary><p className="text-xs text-foreground/70 mt-1.5 leading-relaxed border-l-2 border-border/30 pl-3">{persona.valueEvidence[i]}</p></details>}
                                                     </div>
                                                 ))}
                                             </div>
                                         </div>
-                                    </div>
-                                )}
+                                    )}
 
-                                {persona.fears && persona.fears.length > 0 && (
-                                    <div className="flex flex-col gap-3">
-                                        <div className="flex items-center gap-3">
-                                            <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">FRICTIONS</h4>
+                                    {persona.fears && persona.fears.length > 0 && (
+                                        <div className="flex flex-col gap-3">
+                                            <div className="flex items-center gap-3">
+                                                <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">FRICTIONS</h4>
+                                            </div>
+                                            <ul className="space-y-5">
+                                                {persona.fears.map((f, i) => (
+                                                    <li key={i} className="flex flex-col">
+                                                        <div className="flex items-center gap-2.5 text-xs text-foreground/70 leading-relaxed">
+                                                            <span className="text-destructive/60 shrink-0 mt-0.5">/</span>
+                                                            {f}
+                                                        </div>
+                                                        {persona.fearEvidence?.[i] && <details className="mt-1.5 group ml-4"><summary className="text-xs text-muted-foreground/60 cursor-pointer hover:text-foreground transition-colors list-none flex items-center gap-1.5 font-sans"><span className="text-xs text-muted-foreground/30 group-open:text-foreground/60 transition-colors">▶</span> Source</summary><p className="text-xs text-foreground/70 mt-1.5 leading-relaxed border-l-2 border-border/30 pl-3">{persona.fearEvidence[i]}</p></details>}
+                                                    </li>
+                                                ))}
+                                            </ul>
                                         </div>
-                                        <ul className="space-y-3">
-                                            {persona.fears.map((f, i) => (
-                                                <li key={i} className="flex flex-col">
-                                                    <div className="flex items-center gap-2.5 text-xs text-foreground/70 leading-relaxed">
-                                                        <span className="text-destructive/60 shrink-0 mt-0.5">/</span>
-                                                        {f}
-                                                    </div>
-                                                    {persona.fearEvidence?.[i] && <details className="mt-1 group ml-4"><summary className="text-[10px] text-muted-foreground/50 cursor-pointer hover:text-foreground/70 transition-colors list-none flex items-center gap-1.5 font-sans"><span className="text-[10px] leading-none">▶</span> Source</summary><p className="text-[11px] text-foreground/60 italic mt-1 leading-relaxed border-l-2 border-border/30 pl-3">{persona.fearEvidence[i]}</p></details>}
-                                                </li>
-                                            ))}
-                                        </ul>
-                                    </div>
-                                )}
+                                    )}
                                 </div>
 
                                 {/* TIER 3 */}
                                 <div className="flex flex-col gap-5 mt-6 border-t border-border/10 pt-6">
 
-                                <div className="flex flex-col gap-3">
-                                    <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">EVIDENCE &amp; CONFIDENCE</h4>
-                                    {persona.provenance ? (
-                                        <>
-                                            {persona.provenance.attributes.length > 0 && (
-                                                <div className="grid grid-cols-2 gap-x-4 gap-y-2 mt-1">
-                                                    {[...persona.provenance.attributes].sort((a, b) => b.confidence - a.confidence).map((attr, i) => {
-                                                        const tc = attr.tier === 'observed' ? 'bg-emerald-500' : attr.tier === 'interpreted' ? 'bg-amber-400' : 'bg-gray-400';
-                                                        return (
-                                                            <div key={i} className="group relative flex items-center gap-2.5 text-xs">
-                                                                <span className={'w-1.5 h-1.5 rounded-full shrink-0 ' + tc} />
-                                                                <div className="flex-1 min-w-0 flex items-center gap-2">
-                                                                    <span className="text-foreground/70 truncate">{attr.attribute}</span>
-                                                                    <span className="text-muted-foreground/40 text-[10px] font-mono">{attr.confidence >= 0.8 ? 'High' : attr.confidence >= 0.6 ? 'Moderate' : 'Low'}</span>
-                                                                </div>
-                                                                {attr.evidence && (
-                                                                    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 w-56 p-2.5 rounded-lg border border-border bg-card text-[11px] text-foreground/80 leading-relaxed opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-50 pointer-events-none">
-                                                                        {attr.evidence}
+                                    <div className="flex flex-col gap-4">
+                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">EVIDENCE &amp; CONFIDENCE</h4>
+                                        {persona.provenance ? (
+                                            <>
+                                                {persona.provenance.attributes.length > 0 && (
+                                                    <div className="grid grid-cols-2 gap-x-6 gap-y-4 mt-1">
+                                                        {[...persona.provenance.attributes].sort((a, b) => b.confidence - a.confidence).map((attr, i) => {
+                                                            const tc = attr.tier === 'observed' ? 'bg-emerald-500' : attr.tier === 'interpreted' ? 'bg-amber-400' : 'bg-gray-400';
+                                                            return (
+                                                                <div key={i} className="group relative flex items-center gap-3 text-sm">
+                                                                    <span className={'w-2 h-2 rounded-full shrink-0 ' + tc} />
+                                                                    <div className="flex-1 min-w-0 flex items-center gap-2">
+                                                                        <span className="text-foreground/80 truncate">{attr.attribute}</span>
+                                                                        <span className="text-muted-foreground/60 text-xs font-mono">{attr.confidence >= 0.8 ? 'High' : attr.confidence >= 0.6 ? 'Moderate' : 'Low'}</span>
                                                                     </div>
-                                                                )}
-                                                            </div>
-                                                        );
-                                                    })}
-                                                </div>
-                                            )}
-                                        </>
-                                    ) : (
-                                        <p className="text-xs text-muted-foreground/60">
-                                            {persona.generationMode === 'research' ? "No provenance data available" : "Generated from a description."}
-                                        </p>
-                                    )}
-                                </div>
-
-                                {persona.evidenceLinks && persona.evidenceLinks.length > 0 && (
-                                    <div className="flex flex-col gap-3">
-                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">SOURCES</h4>
-                                        <div className="flex flex-col gap-2">
-                                            {persona.evidenceLinks.map((link, i) => (
-                                                <div key={i} className="relative pl-4 border-l-2 border-border/40">
-                                                    <div className="flex items-center gap-2 mb-1">
-                                                        <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">{link.attribute}</span>
-                                                        <span className="text-[10px] text-muted-foreground/40">{link.transcriptId}</span>
+                                                                    {attr.evidence && (
+                                                                        <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 p-3 rounded-lg border border-border bg-card text-xs text-foreground/80 leading-relaxed opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-50 pointer-events-none shadow-lg">
+                                                                            {attr.evidence}
+                                                                        </div>
+                                                                    )}
+                                                                </div>
+                                                            );
+                                                        })}
                                                     </div>
-                                                    <p className="text-xs text-foreground/70 italic leading-relaxed">{link.excerpt}</p>
-                                                </div>
-                                            ))}
-                                        </div>
+                                                )}
+                                            </>
+                                        ) : (
+                                            <p className="text-sm text-muted-foreground/60">
+                                                {persona.generationMode === 'research' ? "No provenance data available" : "Generated from a description."}
+                                            </p>
+                                        )}
                                     </div>
-                                )}
+
+                                    {persona.evidenceLinks && persona.evidenceLinks.length > 0 && (
+                                        <div className="flex flex-col gap-4">
+                                            <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">SOURCES</h4>
+                                        <div className="flex flex-col gap-5">
+                                            {persona.evidenceLinks.map((link, i) => (
+                                                    <div key={i} className="relative pl-4 border-l-2 border-border/40">
+                                                        <div className="flex items-center gap-2 mb-1.5">
+                                                            <span className="text-xs font-medium text-primary/70 uppercase tracking-wider">{link.attribute}</span>
+                                                            <span className="text-xs text-muted-foreground/50">{link.transcriptId}</span>
+                                                        </div>
+                                                        <p className="text-sm text-foreground/70 leading-relaxed">{link.excerpt}</p>
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        </div>
+                                    )}
                                 </div>
 
                                 <div className="flex flex-col gap-3 mt-6 border-t border-border/10 pt-6">
 
-                                <details className="group">
-                                    <summary className="text-xs font-bold text-muted-foreground uppercase tracking-widest cursor-pointer hover:text-foreground transition-colors list-none flex items-center gap-2 py-1">
-                                        <span className="text-[10px] text-muted-foreground/30 group-open:rotate-90 transition-transform duration-150">{'▶'}</span>
-                                        ADDITIONAL CONTEXT
-                                    </summary>
-                                    <div className="flex flex-col gap-4 pt-4 pb-2">
-                                        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-                                            {persona.age && <span>{persona.age} years old</span>}
-                                            {persona.educationLevel && <><span className="w-1 h-1 rounded-full bg-border" /><span>{persona.educationLevel}</span></>}
-                                            {persona.occupation && <><span className="w-1 h-1 rounded-full bg-border" /><span>{persona.occupation}</span></>}
-                                        </div>
-                                        {persona.backstory && (
-                                            <div className="flex flex-col gap-2">
-                                                <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">BACKSTORY</h4>
-                                                <div className="relative">
-                                                    <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-muted-foreground/50" />
-                                                    <Input placeholder="Search..." value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} className="h-8 text-xs pl-8 rounded-md bg-muted/30 border-none" />
+                                    <details className="group">
+                                        <summary className="text-xs font-bold text-muted-foreground uppercase tracking-widest cursor-pointer hover:text-foreground transition-colors list-none flex items-center gap-2 py-1">
+                                            <span className="text-[10px] text-muted-foreground/30 group-open:rotate-90 transition-transform duration-150">{'▶'}</span>
+                                            ADDITIONAL CONTEXT
+                                        </summary>
+                                        <div className="flex flex-col gap-4 pt-4 pb-2">
+                                            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                                                {persona.age && <span>{persona.age} years old</span>}
+                                                {persona.educationLevel && <><span className="w-1 h-1 rounded-full bg-border" /><span>{persona.educationLevel}</span></>}
+                                                {persona.occupation && <><span className="w-1 h-1 rounded-full bg-border" /><span>{persona.occupation}</span></>}
+                                            </div>
+                                            {persona.backstory && (
+                                                <div className="flex flex-col gap-2">
+                                                    <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">BACKSTORY</h4>
+                                                    <div className="relative">
+                                                        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-muted-foreground/50" />
+                                                        <Input placeholder="Search..." value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} className="h-8 text-xs pl-8 rounded-md bg-muted/30 border-none" />
+                                                    </div>
+                                                    <div className="flex flex-col gap-3 max-h-[200px] overflow-y-auto custom-scrollbar pr-1">
+                                                        {filteredBackstory.map((paragraph, i) => (
+                                                            <p key={persona.id + '-para-' + i} className={cn("text-sm leading-relaxed text-foreground/70",
+                                                                searchTerm && paragraph.toLowerCase().includes(searchTerm.toLowerCase()) ? "bg-primary/5 rounded-lg p-2" : ""
+                                                            )}>{paragraph}</p>
+                                                        ))}
+                                                    </div>
                                                 </div>
-                                                <div className="flex flex-col gap-3 max-h-[200px] overflow-y-auto custom-scrollbar pr-1">
-                                                    {filteredBackstory.map((paragraph, i) => (
-                                                        <p key={persona.id + '-para-' + i} className={cn("text-sm leading-relaxed text-foreground/70",
-                                                            searchTerm && paragraph.toLowerCase().includes(searchTerm.toLowerCase()) ? "bg-primary/5 rounded-lg p-2" : ""
-                                                        )}>{paragraph}</p>
+                                            )}
+                                            {(persona.identityContext || persona.situationContext) && (
+                                                <div className="flex flex-col gap-2">
+                                                    {persona.identityContext && <p className="text-xs text-foreground/70"><span className="text-muted-foreground">Stable</span> {persona.identityContext}</p>}
+                                                    {persona.situationContext && <p className="text-xs text-foreground/70"><span className="text-muted-foreground">Context</span> {persona.situationContext}</p>}
+                                                </div>
+                                            )}
+                                            {persona.clusterInfo && (
+                                                <div className="text-xs text-muted-foreground/70">
+                                                    Represents {persona.clusterInfo.representedCount} interview subjects
+                                                    {persona.clusterInfo.sourceIds.length > 0 && (' (' + persona.clusterInfo.sourceIds.join(', ') + ')')}
+                                                </div>
+                                            )}
+                                        </div>
+                                    </details>
+
+                                    <details className="group">
+                                        <summary className="text-xs font-bold text-muted-foreground uppercase tracking-widest cursor-pointer hover:text-foreground transition-colors list-none flex items-center gap-2 py-1">
+                                            <span className="text-[10px] text-muted-foreground/30 group-open:rotate-90 transition-transform duration-150">{'▶'}</span>
+                                            ADVANCED MODEL DETAILS
+                                        </summary>
+                                        <div className="flex flex-col gap-5 pt-4 pb-2">
+                                            <div className="space-y-4">
+                                                {renderScalar("Conscientiousness", persona.conscientiousness, "Chaotic", "Meticulous")}
+                                                {renderScalar("Neuroticism", persona.neuroticism, "Stable", "Anxious")}
+                                                {renderScalar("Openness", persona.openness, "Traditional", "Curious")}
+                                                {renderScalar("Extraversion", persona.extraversion, "Introvert", "Extrovert")}
+                                                {renderScalar("Agreeableness", persona.agreeableness, "Competitive", "Compassionate")}
+                                            </div>
+                                            {persona.communicationStyle && <p className="text-xs text-foreground/70">Communication: {persona.communicationStyle}</p>}
+                                            {persona.interests && persona.interests.length > 0 && (
+                                                <div className="flex flex-wrap gap-1.5">
+                                                    {persona.interests.map((v, i) => (
+                                                        <span key={i} className="text-[11px] text-muted-foreground bg-secondary/30 px-2 py-0.5 rounded-sm">{v}</span>
                                                     ))}
                                                 </div>
-                                            </div>
-                                        )}
-                                        {(persona.identityContext || persona.situationContext) && (
-                                            <div className="flex flex-col gap-2">
-                                                {persona.identityContext && <p className="text-xs text-foreground/70"><span className="text-muted-foreground">Stable</span> {persona.identityContext}</p>}
-                                                {persona.situationContext && <p className="text-xs text-foreground/70"><span className="text-muted-foreground">Context</span> {persona.situationContext}</p>}
-                                            </div>
-                                        )}
-                                        {persona.clusterInfo && (
-                                            <div className="text-xs text-muted-foreground/70">
-                                                Represents {persona.clusterInfo.representedCount} interview subjects
-                                                {persona.clusterInfo.sourceIds.length > 0 && (' (' + persona.clusterInfo.sourceIds.join(', ') + ')')}
-                                            </div>
-                                        )}
-                                    </div>
-                                </details>
-
-                                <details className="group">
-                                    <summary className="text-xs font-bold text-muted-foreground uppercase tracking-widest cursor-pointer hover:text-foreground transition-colors list-none flex items-center gap-2 py-1">
-                                        <span className="text-[10px] text-muted-foreground/30 group-open:rotate-90 transition-transform duration-150">{'▶'}</span>
-                                        ADVANCED MODEL DETAILS
-                                    </summary>
-                                    <div className="flex flex-col gap-5 pt-4 pb-2">
-                                        <div className="space-y-4">
-                                            {renderScalar("Conscientiousness", persona.conscientiousness, "Chaotic", "Meticulous")}
-                                            {renderScalar("Neuroticism", persona.neuroticism, "Stable", "Anxious")}
-                                            {renderScalar("Openness", persona.openness, "Traditional", "Curious")}
-                                            {renderScalar("Extraversion", persona.extraversion, "Introvert", "Extrovert")}
-                                            {renderScalar("Agreeableness", persona.agreeableness, "Competitive", "Compassionate")}
+                                            )}
+                                            {persona.pbjRationales && (
+                                                <div className="flex flex-col gap-2 pt-2 border-t border-border/10">
+                                                    <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">PSYCHOLOGICAL RATIONALES (PB&amp;J)</h4>
+                                                    <div className="text-xs text-foreground/70 leading-relaxed whitespace-pre-wrap max-h-[300px] overflow-y-auto custom-scrollbar">{persona.pbjRationales}</div>
+                                                </div>
+                                            )}
                                         </div>
-                                        {persona.communicationStyle && <p className="text-xs text-foreground/70">Communication: {persona.communicationStyle}</p>}
-                                        {persona.interests && persona.interests.length > 0 && (
-                                            <div className="flex flex-wrap gap-1.5">
-                                                {persona.interests.map((v, i) => (
-                                                    <span key={i} className="text-[11px] text-muted-foreground bg-secondary/30 px-2 py-0.5 rounded-sm">{v}</span>
-                                                ))}
-                                            </div>
-                                        )}
-                                        {persona.pbjRationales && (
-                                            <div className="flex flex-col gap-2 pt-2 border-t border-border/10">
-                                                <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">PSYCHOLOGICAL RATIONALES (PB&amp;J)</h4>
-                                                <div className="text-xs text-foreground/70 leading-relaxed whitespace-pre-wrap max-h-[300px] overflow-y-auto custom-scrollbar">{persona.pbjRationales}</div>
-                                            </div>
-                                        )}
-                                    </div>
-                                </details>
+                                    </details>
                                 </div>
                             </div>
                         </ScrollArea>
@@ -636,7 +642,7 @@ export function PersonaDetailSheet({
                                             <Input
                                                 type="number"
                                                 value={draftPersona.age}
-                      onChange={(e) => updateDraft({ age: Math.max(0, Math.min(120, Number(e.target.value) || 0)) })}
+                                                onChange={(e) => updateDraft({ age: Math.max(0, Math.min(120, Number(e.target.value) || 0)) })}
                                                 className="h-9 text-sm bg-muted/30 border border-transparent focus:border-primary/50 focus:ring-2 focus:ring-primary/15"
                                             />
                                         </div>

--- a/src/components/custom/PersonaDetailSheet.tsx
+++ b/src/components/custom/PersonaDetailSheet.tsx
@@ -376,7 +376,59 @@ export function PersonaDetailSheet({
                                     </div>
                                 )}
 
-                                {(persona.bestFor || persona.lessReliableFor) && (
+                                <div className="flex flex-col gap-3">
+                                    <div className="flex items-center gap-3">
+                                            <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">BEHAVIOR PATTERNS</h4>
+                                    </div>
+                                    {persona.behavioralDimensions && persona.behavioralDimensions.length > 0 ? (
+                                        <div className="flex flex-col">
+                                            {[...persona.behavioralDimensions].sort((a, b) => {
+                                                const ap = persona.provenance?.attributes?.find(pa => pa.attribute === a.name);
+                                                const bp = persona.provenance?.attributes?.find(pa => pa.attribute === b.name);
+                                                return (bp?.confidence ?? 0) - (ap?.confidence ?? 0);
+                                            }).map((dim, i) => {
+                                                const label = dim.score >= 80 ? 'Very High' : dim.score >= 60 ? 'High' : dim.score >= 40 ? 'Moderate' : dim.score >= 20 ? 'Low' : 'Very Low';
+                                                const lc = dim.score >= 80 ? 'text-emerald-600' : dim.score >= 60 ? 'text-sky-600' : dim.score >= 40 ? 'text-amber-600' : 'text-gray-400';
+                                                return (
+                                                    <div key={i} className="flex flex-col py-3 border-b border-border/10 last:border-0">
+                                                        <div className="flex items-center gap-2.5">
+                                                            <span className="text-xs font-medium text-foreground">{dim.name}</span>
+                                                            <span className={'text-[10px] font-medium ' + lc}>{label}</span>
+                                                        </div>
+                                                        <p className="text-[11px] text-muted-foreground/60 mt-1 leading-relaxed">{dim.description}</p>
+                                                        {dim.evidence && <details className="mt-1.5 group"><summary className="text-[10px] text-muted-foreground/50 cursor-pointer hover:text-foreground/70 transition-colors list-none flex items-center gap-1.5 font-sans"><span className="text-[10px] leading-none">▶</span> Source</summary><p className="text-[11px] text-foreground/60 italic mt-1.5 leading-relaxed border-l-2 border-border/30 pl-3">{dim.evidence}</p></details>}
+                                                    </div>
+                                                );
+                                            })}
+                                        </div>
+                                    ) : null}
+                                </div>
+
+
+                                <div className="flex flex-col gap-3">
+                                    <div className="flex items-center gap-3">
+                                            <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">DECISION MODEL</h4>
+                                    </div>
+                                    {persona.decisionStyle && <p className="text-xs text-foreground/80"><span className="text-muted-foreground">Style:</span> {persona.decisionStyle}</p>}
+                                    <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground/80">
+                                        <span>Price sensitivity: {persona.pricingSensitivity}/100</span>
+                                        {persona.typicalBudget && <span className="text-muted-foreground/40">/</span>}
+                                        {persona.typicalBudget && <span>{persona.typicalBudget}</span>}
+                                    </div>
+                                    {persona.goals.length > 0 && (
+                                        <div className="flex flex-col gap-1.5 mt-1">
+                                             <span className="text-[11px] font-medium text-muted-foreground">Likely to adopt if helps with</span>
+                                             <div className="flex flex-wrap gap-x-3 gap-y-1">
+                                                 {persona.goals.slice(0, 4).map((g, i) => (
+                                                     <span key={i} className="text-xs text-foreground/80">{g}</span>
+                                                 ))}
+                                             </div>
+                                        </div>
+                                    )}
+                                </div>
+
+
+                                    {(persona.bestFor?.length || persona.lessReliableFor?.length) ? (
                                     <div className="flex flex-col gap-3">
                                         <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">PREDICTION SCOPE</h4>
                                         {persona.bestFor && persona.bestFor.length > 0 && (
@@ -394,60 +446,8 @@ export function PersonaDetailSheet({
                                             </div>
                                         )}
                                     </div>
-                                )}
-
-                                <div className="flex flex-col gap-3">
-                                    <div className="flex items-center gap-3">
-                                            <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">DECISION MODEL</h4>
-                                    </div>
-                                    {persona.decisionStyle && <p className="text-xs text-foreground/80"><span className="text-muted-foreground">Style:</span> {persona.decisionStyle}</p>}
-                                    <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground/80">
-                                        <span>Price sensitivity: {persona.pricingSensitivity}/100</span>
-                                        {persona.typicalBudget && <span className="text-muted-foreground/40">/</span>}
-                                        {persona.typicalBudget && <span>{persona.typicalBudget}</span>}
-                                    </div>
-                                    {persona.goals.length > 0 && (
-                                        <div className="flex flex-col gap-1.5 mt-1">
-                                            <span className="text-[11px] font-medium text-emerald-600">Likely to adopt if helps with</span>
-                                            <div className="flex flex-wrap gap-x-3 gap-y-1">
-                                                {persona.goals.slice(0, 4).map((g, i) => (
-                                                    <span key={i} className="text-xs text-emerald-600/80">{g}</span>
-                                                ))}
-                                            </div>
-                                        </div>
-                                    )}
-                                </div>
-
-                                <div className="flex flex-col gap-3">
-                                    <div className="flex items-center gap-3">
-                                            <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">BEHAVIOR PATTERNS</h4>
-                                    </div>
-                                    {persona.behavioralDimensions && persona.behavioralDimensions.length > 0 ? (
-                                        <div className="flex flex-col">
-                                            {[...persona.behavioralDimensions].sort((a, b) => {
-                                                const ap = persona.provenance?.attributes?.find(pa => pa.attribute === a.name);
-                                                const bp = persona.provenance?.attributes?.find(pa => pa.attribute === b.name);
-                                                return (bp?.confidence ?? 0) - (ap?.confidence ?? 0);
-                                            }).map((dim, i) => {
-                                                const label = dim.score >= 80 ? 'Very High' : dim.score >= 60 ? 'High' : dim.score >= 40 ? 'Moderate' : dim.score >= 20 ? 'Low' : 'Very Low';
-                                                const lc = dim.score >= 80 ? 'text-emerald-600' : dim.score >= 60 ? 'text-sky-600' : dim.score >= 40 ? 'text-amber-600' : 'text-gray-400';
-                                                return (
-                                                    <div key={i} className="flex items-start gap-3 py-3 border-b border-border/10 last:border-0">
-                                                        <div className="flex-1 min-w-0">
-                                                            <div className="flex items-center gap-2.5">
-                                                                <span className="text-xs font-medium text-foreground">{dim.name}</span>
-                                                                <span className={'text-[10px] font-medium ' + lc}>{label}</span>
-                                                            </div>
-                                                            <p className="text-[11px] text-muted-foreground/60 mt-1 leading-relaxed">{dim.description}</p>
-                                                        </div>
-                                                            {dim.evidence && <details className="mt-1 group"><summary className="text-[10px] text-muted-foreground/40 cursor-pointer hover:text-foreground/60 transition-colors list-none flex items-center gap-1 font-sans">▶ Source</summary><p className="text-[11px] text-foreground/60 italic mt-1.5 leading-relaxed border-l-2 border-border/30 pl-2.5">{dim.evidence}</p></details>}
-                                                    </div>
-                                                );
-                                            })}
-                                        </div>
                                     ) : null}
-                                </div>
-
+                                    
                                 {/* TIER 2 */}
                                 <div className="flex flex-col gap-6">
 
@@ -456,10 +456,15 @@ export function PersonaDetailSheet({
                                         <div className="flex items-center gap-3">
                                             <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">MOTIVATIONS</h4>
                                         </div>
-                                        <div className="flex flex-wrap gap-2">
-                                            {persona.values.map((v, i) => (
-                                                <span key={i} className="inline-flex items-center text-xs font-medium text-foreground bg-secondary/50 border border-border/30 rounded-full px-3 py-1">{v}</span>
-                                            ))}
+                                        <div className="flex flex-col gap-2">
+                                            <div className="flex flex-wrap gap-2">
+                                                {persona.values.map((v, i) => (
+                                                    <div key={i} className="flex flex-col">
+                                                        <span className="inline-flex items-center text-xs font-medium text-foreground bg-secondary/50 border border-border/30 rounded-full px-3 py-1">{v}</span>
+                                                        {persona.valueEvidence?.[i] && <details className="mt-1 group"><summary className="text-[10px] text-muted-foreground/50 cursor-pointer hover:text-foreground/70 transition-colors list-none flex items-center gap-1.5 font-sans pl-1"><span className="text-[10px] leading-none">▶</span> Source</summary><p className="text-[11px] text-foreground/60 italic mt-1 leading-relaxed border-l-2 border-border/30 pl-3 ml-1">{persona.valueEvidence[i]}</p></details>}
+                                                    </div>
+                                                ))}
+                                            </div>
                                         </div>
                                     </div>
                                 )}
@@ -469,11 +474,14 @@ export function PersonaDetailSheet({
                                         <div className="flex items-center gap-3">
                                             <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">FRICTIONS</h4>
                                         </div>
-                                        <ul className="space-y-2">
+                                        <ul className="space-y-3">
                                             {persona.fears.map((f, i) => (
-                                                <li key={i} className="text-xs text-foreground/70 flex gap-2.5 leading-relaxed">
-                                                    <span className="text-destructive/60 shrink-0 mt-0.5">/</span>
-                                                    {f}
+                                                <li key={i} className="flex flex-col">
+                                                    <div className="flex items-center gap-2.5 text-xs text-foreground/70 leading-relaxed">
+                                                        <span className="text-destructive/60 shrink-0 mt-0.5">/</span>
+                                                        {f}
+                                                    </div>
+                                                    {persona.fearEvidence?.[i] && <details className="mt-1 group ml-4"><summary className="text-[10px] text-muted-foreground/50 cursor-pointer hover:text-foreground/70 transition-colors list-none flex items-center gap-1.5 font-sans"><span className="text-[10px] leading-none">▶</span> Source</summary><p className="text-[11px] text-foreground/60 italic mt-1 leading-relaxed border-l-2 border-border/30 pl-3">{persona.fearEvidence[i]}</p></details>}
                                                 </li>
                                             ))}
                                         </ul>
@@ -490,7 +498,7 @@ export function PersonaDetailSheet({
                                         <>
                                             {persona.provenance.attributes.length > 0 && (
                                                 <div className="grid grid-cols-2 gap-x-4 gap-y-2 mt-1">
-                                                    {persona.provenance.attributes.map((attr, i) => {
+                                                    {[...persona.provenance.attributes].sort((a, b) => b.confidence - a.confidence).map((attr, i) => {
                                                         const tc = attr.tier === 'observed' ? 'bg-emerald-500' : attr.tier === 'interpreted' ? 'bg-amber-400' : 'bg-gray-400';
                                                         return (
                                                             <div key={i} className="group relative flex items-center gap-2.5 text-xs">

--- a/src/components/custom/PersonaDetailSheet.tsx
+++ b/src/components/custom/PersonaDetailSheet.tsx
@@ -376,27 +376,6 @@ export function PersonaDetailSheet({
                                     </div>
                                 )}
 
-{/* TIER 1 */}
-
-                                <div className="flex flex-col gap-8 mt-8">
-
-                                <div className="flex flex-col gap-3">
-                                    <div className="flex items-center gap-3">
-                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">BEHAVIOR SUMMARY</h4>
-                                        {persona.provenance && (
-                                            <span className="inline-flex items-center gap-1.5 text-[10px] font-medium text-muted-foreground bg-secondary/40 border border-border/30 rounded-full px-2.5 py-0.5">
-                                                <span className="w-1 h-1 rounded-full bg-primary/60" />
-                                                {Math.round(persona.provenance.overallConfidence * 100)}%
-                                            </span>
-                                        )}
-                                    </div>
-                                    {persona.backstory ? (
-                                        <p className="text-xs text-foreground/80 leading-relaxed max-w-prose">{persona.backstory.split('\n\n')[0]}</p>
-                                    ) : (
-                                        <p className="text-xs text-muted-foreground/60 italic">No summary available</p>
-                                    )}
-                                </div>
-
                                 {(persona.bestFor || persona.lessReliableFor) && (
                                     <div className="flex flex-col gap-3">
                                         <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">PREDICTION SCOPE</h4>
@@ -419,13 +398,7 @@ export function PersonaDetailSheet({
 
                                 <div className="flex flex-col gap-3">
                                     <div className="flex items-center gap-3">
-                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">DECISION MODEL</h4>
-                                        {persona.provenance && (
-                                            <span className="inline-flex items-center gap-1.5 text-[10px] font-medium text-muted-foreground bg-secondary/40 border border-border/30 rounded-full px-2.5 py-0.5">
-                                                <span className="w-1 h-1 rounded-full bg-primary/60" />
-                                                {Math.round(persona.provenance.overallConfidence * 100)}%
-                                            </span>
-                                        )}
+                                            <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">DECISION MODEL</h4>
                                     </div>
                                     {persona.decisionStyle && <p className="text-xs text-foreground/80"><span className="text-muted-foreground">Style:</span> {persona.decisionStyle}</p>}
                                     <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground/80">
@@ -447,13 +420,7 @@ export function PersonaDetailSheet({
 
                                 <div className="flex flex-col gap-3">
                                     <div className="flex items-center gap-3">
-                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">BEHAVIOR PATTERNS</h4>
-                                        {persona.provenance && (
-                                            <span className="inline-flex items-center gap-1.5 text-[10px] font-medium text-muted-foreground bg-secondary/40 border border-border/30 rounded-full px-2.5 py-0.5">
-                                                <span className="w-1 h-1 rounded-full bg-primary/60" />
-                                                {Math.round(persona.provenance.overallConfidence * 100)}%
-                                            </span>
-                                        )}
+                                            <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">BEHAVIOR PATTERNS</h4>
                                     </div>
                                     {persona.behavioralDimensions && persona.behavioralDimensions.length > 0 ? (
                                         <div className="flex flex-col">
@@ -473,35 +440,21 @@ export function PersonaDetailSheet({
                                                             </div>
                                                             <p className="text-[11px] text-muted-foreground/60 mt-1 leading-relaxed">{dim.description}</p>
                                                         </div>
-                                                        {dim.evidence && (
-                                                            <div className="group relative shrink-0 mt-0.5">
-                                                                <span className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-secondary/60 text-muted-foreground/50 cursor-help text-[9px] font-bold">?</span>
-                                                                <div className="absolute right-0 top-full mt-1.5 w-60 p-2.5 rounded-lg border border-border bg-card text-[11px] text-foreground/80 leading-relaxed opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-50 pointer-events-none">
-                                                                    {dim.evidence}
-                                                                </div>
-                                                            </div>
-                                                        )}
+                                                            {dim.evidence && <details className="mt-1 group"><summary className="text-[10px] text-muted-foreground/40 cursor-pointer hover:text-foreground/60 transition-colors list-none flex items-center gap-1 font-sans">▶ Source</summary><p className="text-[11px] text-foreground/60 italic mt-1.5 leading-relaxed border-l-2 border-border/30 pl-2.5">{dim.evidence}</p></details>}
                                                     </div>
                                                 );
                                             })}
                                         </div>
                                     ) : null}
                                 </div>
-                                </div>
 
                                 {/* TIER 2 */}
-                                <div className="flex flex-col gap-6 mt-8">
+                                <div className="flex flex-col gap-6">
 
                                 {persona.values && persona.values.length > 0 && (
                                     <div className="flex flex-col gap-3">
                                         <div className="flex items-center gap-3">
                                             <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">MOTIVATIONS</h4>
-                                            {persona.provenance && (
-                                                <span className="inline-flex items-center gap-1.5 text-[10px] font-medium text-muted-foreground bg-secondary/40 border border-border/30 rounded-full px-2.5 py-0.5">
-                                                    <span className="w-1 h-1 rounded-full bg-primary/60" />
-                                                    {Math.round(persona.provenance.overallConfidence * 100)}%
-                                                </span>
-                                            )}
                                         </div>
                                         <div className="flex flex-wrap gap-2">
                                             {persona.values.map((v, i) => (
@@ -515,12 +468,6 @@ export function PersonaDetailSheet({
                                     <div className="flex flex-col gap-3">
                                         <div className="flex items-center gap-3">
                                             <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">FRICTIONS</h4>
-                                            {persona.provenance && (
-                                                <span className="inline-flex items-center gap-1.5 text-[10px] font-medium text-muted-foreground bg-secondary/40 border border-border/30 rounded-full px-2.5 py-0.5">
-                                                    <span className="w-1 h-1 rounded-full bg-primary/60" />
-                                                    {Math.round(persona.provenance.overallConfidence * 100)}%
-                                                </span>
-                                            )}
                                         </div>
                                         <ul className="space-y-2">
                                             {persona.fears.map((f, i) => (
@@ -541,13 +488,6 @@ export function PersonaDetailSheet({
                                     <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">EVIDENCE &amp; CONFIDENCE</h4>
                                     {persona.provenance ? (
                                         <>
-                                            <div className="flex items-center gap-3 text-xs">
-                                                <span className="text-muted-foreground">Overall</span>
-                                                <div className="flex-1 h-1 max-w-[80px] rounded-full bg-secondary">
-                                                    <div className="h-full rounded-full bg-primary" style={{ width: persona.provenance.overallConfidence * 100 + '%' }} />
-                                                </div>
-                                                <span className="font-mono text-muted-foreground/60 text-[11px]">{Math.round(persona.provenance.overallConfidence * 100)}%</span>
-                                            </div>
                                             {persona.provenance.attributes.length > 0 && (
                                                 <div className="grid grid-cols-2 gap-x-4 gap-y-2 mt-1">
                                                     {persona.provenance.attributes.map((attr, i) => {
@@ -557,7 +497,7 @@ export function PersonaDetailSheet({
                                                                 <span className={'w-1.5 h-1.5 rounded-full shrink-0 ' + tc} />
                                                                 <div className="flex-1 min-w-0 flex items-center gap-2">
                                                                     <span className="text-foreground/70 truncate">{attr.attribute}</span>
-                                                                    <span className="text-muted-foreground/40 text-[10px] font-mono">{Math.round(attr.confidence * 100)}%</span>
+                                                                    <span className="text-muted-foreground/40 text-[10px] font-mono">{attr.confidence >= 0.8 ? 'High' : attr.confidence >= 0.6 ? 'Moderate' : 'Low'}</span>
                                                                 </div>
                                                                 {attr.evidence && (
                                                                     <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 w-56 p-2.5 rounded-lg border border-border bg-card text-[11px] text-foreground/80 leading-relaxed opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-50 pointer-events-none">

--- a/src/components/custom/PersonaDetailSheet.tsx
+++ b/src/components/custom/PersonaDetailSheet.tsx
@@ -372,59 +372,152 @@ export function PersonaDetailSheet({
                                 )}
                                 {counterfactualResults && counterfactualResults.length === 0 && (
                                     <div className="flex flex-col gap-1 rounded-lg border border-green-200 bg-green-50/50 p-3">
-                                        <p className="text-xs font-medium text-green-700">✓ All synthetic details pass counterfactual test</p>
+                                        <p className="text-xs font-medium text-green-700">✓ All details pass counterfactual test</p>
                                     </div>
                                 )}
 
-                                {/* Behavioral Model — derived from behavioralDimensions or existing data */}
-                                <div className="flex flex-col gap-3">
-                                    <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">BEHAVIOR</h4>
-                                    {persona.behavioralDimensions && persona.behavioralDimensions.length > 0 ? (
-                                        <div className="space-y-3">
-                                            {persona.behavioralDimensions.map((dim, i) => (
-                                                <div key={i} className="flex flex-col gap-1.5" style={{ opacity: attrOpacity(dim.evidence ? 'observed' : undefined) }}>
-                                                    <div className="flex justify-between items-end">
-                                                        <span className="text-xs font-medium text-foreground">{dim.name}</span>
-                                                        <span className="text-xs font-mono text-muted-foreground">{dim.score}/100</span>
-                                                    </div>
-                                                    <Progress value={dim.score} className="h-1.5" />
-                                                    <div className="flex justify-between text-[11px] text-muted-foreground/60">
-                                                        <span>{dim.context}</span>
-                                                        {dim.evidence && (
-                                                            <span className="text-primary/60 flex items-center gap-1" title={dim.evidence}>
-                                                                ● evidence
-                                                            </span>
-                                                        )}
-                                                    </div>
-                                                    <p className="text-xs text-muted-foreground/80">{dim.description}</p>
-                                                </div>
-                                            ))}
-                                        </div>
+                                {/* 1. Behavior Summary */}
+                                <div className="flex flex-col gap-2">
+                                    <div className="flex items-center gap-2">
+                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">BEHAVIOR SUMMARY</h4>
+                                        {persona.provenance && (
+                                            <span className="text-[10px] text-muted-foreground/50 bg-secondary/40 px-1.5 py-0.5 rounded-sm">
+                                                {Math.round(persona.provenance.overallConfidence * 100)}% confidence
+                                            </span>
+                                        )}
+                                    </div>
+                                    {persona.backstory ? (
+                                        <p className="text-xs text-foreground/80 leading-relaxed">
+                                            {persona.backstory.split('\n\n')[0]}
+                                        </p>
                                     ) : (
-                                        <div className="flex flex-col gap-2">
-                                            {persona.goals.length > 0 && (
-                                                <div className="flex flex-col gap-2">
-                                                    {persona.goals.map((goal, i) => (
-                                                        <div key={i} className="flex items-center gap-2 text-xs text-foreground/80">
-                                                            <span className="text-primary shrink-0">✓</span>
-                                                            {goal}
-                                                        </div>
+                                        <p className="text-xs text-muted-foreground/60 italic">No summary available</p>
+                                    )}
+                                </div>
+
+                                {/* Best For / Less Reliable For */}
+                                {(persona.bestFor || persona.lessReliableFor) && (
+                                    <div className="flex flex-col gap-2">
+                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">PREDICTION SCOPE</h4>
+                                        {persona.bestFor && persona.bestFor.length > 0 && (
+                                            <div className="flex flex-col gap-1">
+                                                <span className="text-[11px] font-medium text-green-700">Best for</span>
+                                                <div className="flex flex-wrap gap-1.5">
+                                                    {persona.bestFor.map((item, i) => (
+                                                        <span key={i} className="inline-flex items-center gap-1 text-[11px] bg-green-50 text-green-700 border border-green-200 px-2 py-0.5 rounded-sm">
+                                                            ✓ {item}
+                                                        </span>
                                                     ))}
                                                 </div>
-                                            )}
-                                            {persona.communicationStyle && (
-                                                <p className="text-xs text-muted-foreground/70 mt-1">
-                                                    Communicates {persona.communicationStyle}
-                                                </p>
-                                            )}
+                                            </div>
+                                        )}
+                                        {persona.lessReliableFor && persona.lessReliableFor.length > 0 && (
+                                            <div className="flex flex-col gap-1 mt-1">
+                                                <span className="text-[11px] font-medium text-amber-600">Less reliable for</span>
+                                                <div className="flex flex-wrap gap-1.5">
+                                                    {persona.lessReliableFor.map((item, i) => (
+                                                        <span key={i} className="inline-flex items-center gap-1 text-[11px] bg-amber-50 text-amber-700 border border-amber-200 px-2 py-0.5 rounded-sm">
+                                                            △ {item}
+                                                        </span>
+                                                    ))}
+                                                </div>
+                                            </div>
+                                        )}
+                                    </div>
+                                )}
+
+                                {/* 2. Decision Model */}
+                                <div className="flex flex-col gap-2">
+                                    <div className="flex items-center gap-2">
+                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">DECISION MODEL</h4>
+                                        {persona.provenance && (
+                                            <span className="text-[10px] text-muted-foreground/50 bg-secondary/40 px-1.5 py-0.5 rounded-sm">
+                                                {Math.round(persona.provenance.overallConfidence * 100)}% confidence
+                                            </span>
+                                        )}
+                                    </div>
+                                    {persona.decisionStyle && (
+                                        <p className="text-xs text-foreground/80">
+                                            <span className="text-muted-foreground">Style:</span> {persona.decisionStyle}
+                                        </p>
+                                    )}
+                                    <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground/80">
+                                        <span>Price sensitivity: {persona.pricingSensitivity}/100</span>
+                                        {persona.typicalBudget && <span>· {persona.typicalBudget}</span>}
+                                    </div>
+                                    {persona.goals.length > 0 && (
+                                        <div className="flex flex-col gap-1 mt-1">
+                                            <span className="text-[11px] font-medium text-green-700">Likely to adopt if helps with:</span>
+                                            <div className="flex flex-wrap gap-1.5">
+                                                {persona.goals.slice(0, 4).map((g, i) => (
+                                                    <span key={i} className="text-xs text-green-700/80">✓ {g}</span>
+                                                ))}
+                                            </div>
                                         </div>
                                     )}
                                 </div>
 
-                                {/* Motivations — from values */}
+                                {/* 3. Behavior Patterns (sorted by confidence descending) */}
+                                <div className="flex flex-col gap-3">
+                                    <div className="flex items-center gap-2">
+                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">BEHAVIOR PATTERNS</h4>
+                                        {persona.provenance && (
+                                            <span className="text-[10px] text-muted-foreground/50 bg-secondary/40 px-1.5 py-0.5 rounded-sm">
+                                                {Math.round(persona.provenance.overallConfidence * 100)}% confidence
+                                            </span>
+                                        )}
+                                    </div>
+                                    {persona.behavioralDimensions && persona.behavioralDimensions.length > 0 ? (
+                                        <div className="space-y-2">
+                                            {[...persona.behavioralDimensions]
+                                                .sort((a, b) => b.score - a.score)
+                                                .map((dim, i) => {
+                                                    const label = dim.score >= 80 ? 'Very High' : dim.score >= 60 ? 'High' : dim.score >= 40 ? 'Moderate' : dim.score >= 20 ? 'Low' : 'Very Low'
+                                                    const labelColor = dim.score >= 80 ? 'text-green-600' : dim.score >= 60 ? 'text-emerald-500' : dim.score >= 40 ? 'text-amber-500' : 'text-gray-400'
+                                                    return (
+                                                        <div key={i} className="flex items-start gap-3 py-1.5 border-b border-border/10 last:border-0">
+                                                            <div className="flex-1 min-w-0">
+                                                                <div className="flex items-center gap-2">
+                                                                    <span className="text-xs font-medium text-foreground">{dim.name}</span>
+                                                                    <span className={`text-[10px] font-medium ${labelColor}`}>{label}</span>
+                                                                </div>
+                                                                <p className="text-[11px] text-muted-foreground/70 mt-0.5">{dim.description}</p>
+                                                            </div>
+                                                            {dim.evidence && (
+                                                                <div className="group relative shrink-0">
+                                                                    <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-primary/10 text-primary cursor-help text-[10px] font-bold">?</span>
+                                                                    <div className="absolute right-0 top-full mt-1 w-56 p-2 rounded-lg border border-border bg-card shadow-lg text-[11px] text-foreground/80 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-50">
+                                                                        {dim.evidence}
+                                                                    </div>
+                                                                </div>
+                                                            )}
+                                                        </div>
+                                                    )
+                                                })}
+                                        </div>
+                                    ) : (
+                                        <div className="flex flex-col gap-1.5">
+                                            {persona.goals.slice(0, 4).map((goal, i) => (
+                                                <div key={i} className="flex items-center gap-2 text-xs text-foreground/80">
+                                                    <span className="text-primary shrink-0">✓</span>
+                                                    {goal}
+                                                </div>
+                                            ))}
+                                        </div>
+                                    )}
+                                </div>
+
+                                {/* 4. Motivations */}
                                 {persona.values && persona.values.length > 0 && (
                                     <div className="flex flex-col gap-2">
-                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">MOTIVATIONS</h4>
+                                        <div className="flex items-center gap-2">
+                                            <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">MOTIVATIONS</h4>
+                                            {persona.provenance && (
+                                                <span className="text-[10px] text-muted-foreground/50 bg-secondary/40 px-1.5 py-0.5 rounded-sm">
+                                                    {Math.round(persona.provenance.overallConfidence * 100)}% confidence
+                                                </span>
+                                            )}
+                                        </div>
                                         <div className="flex flex-wrap gap-1.5">
                                             {persona.values.map((v, i) => (
                                                 <span key={i} className="inline-flex items-center gap-1.5 text-xs font-medium bg-primary/10 text-primary px-2.5 py-1 rounded-sm">
@@ -436,14 +529,21 @@ export function PersonaDetailSheet({
                                     </div>
                                 )}
 
-                                {/* Frictions — from fears */}
+                                {/* 5. Frictions */}
                                 {persona.fears && persona.fears.length > 0 && (
                                     <div className="flex flex-col gap-2">
-                                        <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">FRICTIONS</h4>
+                                        <div className="flex items-center gap-2">
+                                            <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">FRICTIONS</h4>
+                                            {persona.provenance && (
+                                                <span className="text-[10px] text-muted-foreground/50 bg-secondary/40 px-1.5 py-0.5 rounded-sm">
+                                                    {Math.round(persona.provenance.overallConfidence * 100)}% confidence
+                                                </span>
+                                            )}
+                                        </div>
                                         <ul className="space-y-1.5">
                                             {persona.fears.map((f, i) => (
-                                                <li key={i} className="text-xs text-foreground/80 flex gap-2">
-                                                    <span className="text-destructive shrink-0">✕</span>
+                                                <li key={i} className="text-xs text-foreground/80 flex gap-2 leading-relaxed">
+                                                    <span className="text-destructive shrink-0 mt-0.5">✕</span>
                                                     {f}
                                                 </li>
                                             ))}
@@ -451,197 +551,142 @@ export function PersonaDetailSheet({
                                     </div>
                                 )}
 
-                                {/* Decision Model */}
-                                <div className="flex flex-col gap-2">
-                                    <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">DECISION MODEL</h4>
-                                    {persona.decisionStyle && (
-                                        <p className="text-xs text-foreground/80">
-                                            Decision style: <span className="font-medium text-foreground">{persona.decisionStyle}</span>
-                                        </p>
-                                    )}
-                                    <div className="flex gap-3 text-xs text-muted-foreground/80">
-                                        <span>Price sensitivity: {persona.pricingSensitivity}/100</span>
-                                        {persona.typicalBudget && <span>· Budget: {persona.typicalBudget}</span>}
-                                    </div>
-                                    {persona.goals.length > 0 && (
-                                        <div className="mt-1 flex flex-col gap-1">
-                                            <span className="text-[11px] font-medium text-green-700">Likely to adopt if helps with:</span>
-                                            {persona.goals.slice(0, 3).map((g, i) => (
-                                                <span key={i} className="text-xs text-green-700/80 ml-2">✓ {g}</span>
-                                            ))}
-                                        </div>
-                                    )}
-                                </div>
-
-                                {/* Evidence & Confidence */}
-                                <div className="flex flex-col gap-2">
+                                {/* 6. Evidence & Confidence */}
+                                <div className="flex flex-col gap-3">
                                     <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">EVIDENCE &amp; CONFIDENCE</h4>
                                     {persona.provenance ? (
-                                        <div className="flex flex-col gap-2">
+                                        <>
                                             <div className="flex items-center gap-2 text-xs text-foreground/80">
-                                                <span>Overall confidence:</span>
-                                                <div className="flex-1 h-1.5 max-w-[120px] rounded-full bg-secondary">
-                                                    <div
-                                                        className="h-full rounded-full bg-primary transition-all"
-                                                        style={{ width: `${persona.provenance.overallConfidence * 100}%` }}
-                                                    />
+                                                <span>Overall:</span>
+                                                <div className="flex-1 h-1.5 max-w-[100px] rounded-full bg-secondary">
+                                                    <div className="h-full rounded-full bg-primary" style={{ width: `${persona.provenance.overallConfidence * 100}%` }} />
                                                 </div>
-                                                <span className="font-mono text-muted-foreground">
-                                                    {Math.round(persona.provenance.overallConfidence * 100)}%
-                                                </span>
+                                                <span className="font-mono text-muted-foreground text-[11px]">{Math.round(persona.provenance.overallConfidence * 100)}%</span>
                                             </div>
                                             {persona.provenance.attributes.length > 0 && (
-                                                <details className="group">
-                                                    <summary className="text-xs text-muted-foreground hover:text-foreground cursor-pointer list-none flex items-center gap-1">
-                                                        <span className="text-[10px] text-muted-foreground/40 group-open:rotate-90 transition-transform">▶</span>
-                                                        Per-attribute breakdown ({persona.provenance.attributes.length})
-                                                    </summary>
-                                                    <div className="space-y-1 pt-1">
-                                                        {persona.provenance.attributes.map((attr, i) => (
-                                                            <div key={i} className="flex items-center gap-2 text-xs text-foreground/60">
-                                                                <span className={`w-1.5 h-1.5 rounded-full ${
-                                                                    attr.tier === 'observed' ? 'bg-green-500' :
-                                                                    attr.tier === 'interpreted' ? 'bg-amber-400' : 'bg-gray-300'
-                                                                }`} />
-                                                                <span>{attr.attribute}</span>
-                                                                <span className="text-muted-foreground/40">·</span>
-                                                                <span>{attr.tier}</span>
-                                                                <span className="text-muted-foreground/40">·</span>
-                                                                <span>{Math.round(attr.confidence * 100)}%</span>
-                                                            </div>
-                                                        ))}
-                                                    </div>
-                                                </details>
+                                                <div className="flex flex-wrap gap-1.5">
+                                                    {persona.provenance.attributes.map((attr, i) => (
+                                                        <div key={i} className="group relative inline-flex items-center gap-1.5 text-[10px] bg-secondary/30 border border-border/30 rounded-sm px-1.5 py-1">
+                                                            <span className={`w-1.5 h-1.5 rounded-full ${attr.tier === 'observed' ? 'bg-green-500' : attr.tier === 'interpreted' ? 'bg-amber-400' : 'bg-gray-300'}`} />
+                                                            <span className="text-muted-foreground">{attr.attribute}</span>
+                                                            {attr.confidence < 1 && (
+                                                                <span className="text-muted-foreground/50">{Math.round(attr.confidence * 100)}%</span>
+                                                            )}
+                                                            {attr.evidence && (
+                                                                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 w-48 p-2 rounded-lg border border-border bg-card shadow-lg text-[11px] text-foreground/80 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-50 pointer-events-none">
+                                                                    {attr.evidence}
+                                                                </div>
+                                                            )}
+                                                        </div>
+                                                    ))}
+                                                </div>
                                             )}
-                                        </div>
+                                        </>
                                     ) : (
                                         <p className="text-xs text-muted-foreground/60">
                                             {persona.generationMode === 'research'
                                                 ? "No provenance data available"
-                                                : "This persona was generated from a description, not from interviews. Individual attributes are not linked to specific sources."
+                                                : "Generated from a description. Not linked to interview sources."
                                             }
                                         </p>
                                     )}
                                 </div>
 
-                                {/* Sources */}
+                                {/* 7. Sources */}
                                 {persona.evidenceLinks && persona.evidenceLinks.length > 0 && (
                                     <div className="flex flex-col gap-2">
                                         <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">SOURCES</h4>
                                         <div className="space-y-2">
                                             {persona.evidenceLinks.map((link, i) => (
                                                 <div key={i} className="flex flex-col gap-1 rounded-lg border border-border/40 bg-secondary/20 p-3">
-                                                    <span className="text-xs font-medium text-foreground">{link.attribute}</span>
-                                                    <p className="text-xs text-muted-foreground/80 italic">"{link.excerpt}"</p>
-                                                    <span className="text-[10px] text-muted-foreground/60">{link.transcriptId}</span>
+                                                    <div className="flex items-center gap-2">
+                                                        <span className="text-[10px] font-medium text-muted-foreground uppercase">{link.attribute}</span>
+                                                        <span className="text-[10px] text-muted-foreground/50">{link.transcriptId}</span>
+                                                    </div>
+                                                    <p className="text-xs text-foreground/80 italic leading-relaxed">"{link.excerpt}"</p>
                                                 </div>
                                             ))}
                                         </div>
                                     </div>
                                 )}
 
-                                {/* Full Details — collapsible */}
-                                <details className="flex flex-col gap-3 group border-t border-border/20 pt-4">
+                                {/* 8. Additional Context (collapsible) */}
+                                <details className="flex flex-col gap-3 group border-t border-border/10 pt-3">
                                     <summary className="text-xs font-bold text-muted-foreground uppercase tracking-widest cursor-pointer hover:text-foreground transition-colors list-none flex items-center gap-2">
-                                        <span className="text-[10px] text-muted-foreground/40 group-open:rotate-90 transition-transform">▶</span>
-                                        FULL DETAILS
+                                        <span className="text-[10px] text-muted-foreground/30 group-open:rotate-90 transition-transform">▶</span>
+                                        ADDITIONAL CONTEXT
                                     </summary>
-                                    <div className="flex flex-col gap-5 pt-3">
-
-                                        {/* Quick Info */}
+                                    <div className="flex flex-col gap-4 pt-3">
                                         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-                                            <span>{persona.age} years old</span>
-                                            <span className="w-1 h-1 rounded-full bg-border" />
-                                            <span>{persona.educationLevel}</span>
-                                            {persona.occupation && (
-                                                <><span className="w-1 h-1 rounded-full bg-border" /><span>{persona.occupation}</span></>
-                                            )}
+                                            {persona.age && <span>{persona.age} years old</span>}
+                                            {persona.educationLevel && <><span className="w-1 h-1 rounded-full bg-border" /><span>{persona.educationLevel}</span></>}
+                                            {persona.occupation && <><span className="w-1 h-1 rounded-full bg-border" /><span>{persona.occupation}</span></>}
                                         </div>
 
-                                        {/* Backstory */}
                                         {persona.backstory && (
-                                            <div className="flex flex-col gap-3">
-                                                <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">BACKSTORY</h4>
+                                            <div className="flex flex-col gap-2">
+                                                <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">BACKSTORY</h4>
                                                 <div className="relative">
                                                     <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-muted-foreground/50" />
-                                                    <Input
-                                                        placeholder="Search backstory..."
-                                                        value={searchTerm}
-                                                        onChange={(e) => setSearchTerm(e.target.value)}
-                                                        className="h-8 text-xs pl-8 rounded-md bg-muted/30 border-none transition-all focus:ring-1 focus:ring-primary/20"
-                                                    />
+                                                    <Input placeholder="Search..." value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} className="h-8 text-xs pl-8 rounded-md bg-muted/30 border-none" />
                                                 </div>
-                                                <div className="flex flex-col gap-4 max-h-[240px] overflow-y-auto custom-scrollbar pr-1">
+                                                <div className="flex flex-col gap-3 max-h-[200px] overflow-y-auto custom-scrollbar pr-1">
                                                     {filteredBackstory.map((paragraph, i) => (
-                                                        <p key={`${persona.id}-para-${i}`}
-                                                            className={cn("text-sm md:text-base leading-relaxed text-foreground/80",
-                                                                searchTerm && paragraph.toLowerCase().includes(searchTerm.toLowerCase())
-                                                                    ? "bg-primary/10 rounded-lg p-2 text-foreground font-medium ring-1 ring-primary/20" : ""
-                                                            )}>
-                                                            {paragraph}
-                                                        </p>
+                                                        <p key={`${persona.id}-para-${i}`} className={cn("text-sm leading-relaxed text-foreground/70",
+                                                            searchTerm && paragraph.toLowerCase().includes(searchTerm.toLowerCase()) ? "bg-primary/5 rounded-lg p-2" : ""
+                                                        )}>{paragraph}</p>
                                                     ))}
                                                 </div>
                                             </div>
                                         )}
 
-                                        {/* Big Five */}
-                                        <div className="flex flex-col gap-4">
-                                            <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">PERSONALITY (BIG FIVE)</h4>
-                                            <div className="space-y-4">
-                                                {renderScalar("Conscientiousness", persona.conscientiousness, "Chaotic", "Meticulous")}
-                                                {renderScalar("Neuroticism", persona.neuroticism, "Stable", "Anxious")}
-                                                {renderScalar("Openness", persona.openness, "Traditional", "Curious")}
-                                                {renderScalar("Extraversion", persona.extraversion, "Introvert", "Extrovert")}
-                                                {renderScalar("Agreeableness", persona.agreeableness, "Competitive", "Compassionate")}
-                                            </div>
-                                        </div>
-
-                                        {/* Psychographic */}
-                                        <div className="flex flex-col gap-3">
-                                            <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">PSYCHOGRAPHIC</h4>
-                                            {persona.communicationStyle && (
-                                                <p className="text-xs text-foreground/80">Communicates: {persona.communicationStyle}</p>
-                                            )}
-                                            {persona.interests && persona.interests.length > 0 && (
-                                                <div className="flex flex-wrap gap-1.5">
-                                                    {persona.interests.map((v, i) => (
-                                                        <span key={i} className="text-[11px] text-muted-foreground bg-secondary/40 px-2 py-0.5 rounded-sm">{v}</span>
-                                                    ))}
-                                                </div>
-                                            )}
-                                        </div>
-
-                                        {/* Identity/Situation Context */}
                                         {(persona.identityContext || persona.situationContext) && (
                                             <div className="flex flex-col gap-2">
-                                                {persona.identityContext && (
-                                                    <div className="flex flex-col gap-1">
-                                                        <span className="text-xs font-semibold text-muted-foreground">Stable traits</span>
-                                                        <p className="text-sm text-foreground/80">{persona.identityContext}</p>
-                                                    </div>
-                                                )}
-                                                {persona.situationContext && (
-                                                    <div className="flex flex-col gap-1">
-                                                        <span className="text-xs font-semibold text-muted-foreground">Situational</span>
-                                                        <p className="text-sm text-foreground/80">{persona.situationContext}</p>
-                                                    </div>
-                                                )}
+                                                {persona.identityContext && <p className="text-xs text-foreground/70"><span className="text-muted-foreground">Stable:</span> {persona.identityContext}</p>}
+                                                {persona.situationContext && <p className="text-xs text-foreground/70"><span className="text-muted-foreground">Context:</span> {persona.situationContext}</p>}
                                             </div>
                                         )}
 
-                                        {/* Cluster Info */}
                                         {persona.clusterInfo && (
-                                            <div className="flex flex-col gap-2 rounded-lg border border-border/40 bg-secondary/20 p-3">
-                                                <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">CLUSTER</h4>
-                                                <p className="text-xs text-muted-foreground/80">
-                                                    Represents {persona.clusterInfo.representedCount} interview subjects
-                                                </p>
-                                                {persona.clusterInfo.sourceIds.length > 0 && (
-                                                    <p className="text-xs text-muted-foreground/60">
-                                                        Sources: {persona.clusterInfo.sourceIds.join(", ")}
-                                                    </p>
-                                                )}
+                                            <div className="text-xs text-muted-foreground/70">
+                                                Represents {persona.clusterInfo.representedCount} interview subjects
+                                                {persona.clusterInfo.sourceIds.length > 0 && ` (${persona.clusterInfo.sourceIds.join(", ")})`}
+                                            </div>
+                                        )}
+                                    </div>
+                                </details>
+
+                                {/* 9. Advanced Model Details (collapsible) */}
+                                <details className="flex flex-col gap-3 group">
+                                    <summary className="text-xs font-bold text-muted-foreground uppercase tracking-widest cursor-pointer hover:text-foreground transition-colors list-none flex items-center gap-2">
+                                        <span className="text-[10px] text-muted-foreground/30 group-open:rotate-90 transition-transform">▶</span>
+                                        ADVANCED MODEL DETAILS
+                                    </summary>
+                                    <div className="flex flex-col gap-5 pt-3">
+                                        <div className="space-y-4">
+                                            {renderScalar("Conscientiousness", persona.conscientiousness, "Chaotic", "Meticulous")}
+                                            {renderScalar("Neuroticism", persona.neuroticism, "Stable", "Anxious")}
+                                            {renderScalar("Openness", persona.openness, "Traditional", "Curious")}
+                                            {renderScalar("Extraversion", persona.extraversion, "Introvert", "Extrovert")}
+                                            {renderScalar("Agreeableness", persona.agreeableness, "Competitive", "Compassionate")}
+                                        </div>
+                                        {persona.communicationStyle && (
+                                            <p className="text-xs text-foreground/70">Communication: {persona.communicationStyle}</p>
+                                        )}
+                                        {persona.interests && persona.interests.length > 0 && (
+                                            <div className="flex flex-wrap gap-1.5">
+                                                {persona.interests.map((v, i) => (
+                                                    <span key={i} className="text-[11px] text-muted-foreground bg-secondary/30 px-2 py-0.5 rounded-sm">{v}</span>
+                                                ))}
+                                            </div>
+                                        )}
+                                        {/* PB&J Rationales */}
+                                        {persona.pbjRationales && (
+                                            <div className="flex flex-col gap-2 pt-2 border-t border-border/10">
+                                                <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-widest">PSYCHOLOGICAL RATIONALES (PB&J)</h4>
+                                                <div className="text-xs text-foreground/70 leading-relaxed whitespace-pre-wrap max-h-[300px] overflow-y-auto custom-scrollbar">
+                                                    {persona.pbjRationales}
+                                                </div>
                                             </div>
                                         )}
                                     </div>

--- a/src/components/custom/PersonaProgressToaster.tsx
+++ b/src/components/custom/PersonaProgressToaster.tsx
@@ -3,9 +3,10 @@
 import { useEffect, useRef } from 'react'
 import { toast } from 'sonner'
 import { ClockIcon, CheckCircleIcon, XCircleIcon } from 'lucide-react'
-import { usePersonaStore } from '@/ui/stores/personaStore'
+import { usePersonaStore, type PersonaBatch } from '@/ui/stores/personaStore'
 import { getProgressAction } from '@/actions/getProgress'
 import { getPersonaGenerationResultAction } from '@/actions/getPersonaGenerationResult'
+import { batchConsumedRunIds } from '@/lib/generationRunState'
 
 const POLL_INTERVAL_MS = 1000
 
@@ -81,12 +82,25 @@ export function PersonaProgressToaster() {
 
           completedSet.add(runId)
           removedSet.add(runId)
-          // Remove from active generation tracking so the dashboard
-          // skeleton card is replaced by the batch that usePersonaFlow added.
           usePersonaStore.getState().removeActiveGeneration(runId)
 
           const personaCount = result.personas?.length ?? 0
           const isError = !!result.error
+
+          if (!isError && personaCount > 0 && !batchConsumedRunIds.has(runId)) {
+            batchConsumedRunIds.add(runId)
+            const source = runId.startsWith('pt-') ? 'description' : 'interviews'
+            const label = source === 'interviews' ? `${personaCount} Personas from Interviews` : `${personaCount} Generated Personas`
+            const batch: PersonaBatch = {
+              id: `batch-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`,
+              label,
+              source,
+              transcriptCount: undefined,
+              createdAt: new Date().toISOString(),
+              personas: result.personas!,
+            }
+            usePersonaStore.getState().addBatch(batch)
+          }
 
           const content = (
             <PersonaToastContent

--- a/src/components/custom/PersonaSurveyForm.tsx
+++ b/src/components/custom/PersonaSurveyForm.tsx
@@ -1,0 +1,251 @@
+"use client"
+
+import { useState } from "react"
+import { Textarea } from "@/components/ui/textarea"
+import type { PersonaSurvey } from "@/lib/surveyToPrompt"
+import {
+  GOAL_OPTIONS,
+  FRUSTRATION_OPTIONS,
+  SOLUTION_OPTIONS,
+  DECISION_FACTOR_OPTIONS,
+  AUDIENCE_KNOWLEDGE_OPTIONS,
+  DECISION_TYPE_OPTIONS,
+} from "@/lib/surveyToPrompt"
+import { ArrowRightIcon, SparklesIcon } from "lucide-react"
+
+interface PersonaSurveyFormProps {
+  onSubmit: (survey: PersonaSurvey) => void
+  onUseTextarea: () => void
+  isPending: boolean
+  error?: string | null
+}
+
+function MultiSelect({
+  options,
+  selected,
+  onChange,
+  max,
+  label,
+}: {
+  options: readonly string[]
+  selected: string[]
+  onChange: (vals: string[]) => void
+  max: number
+  label: string
+}) {
+  const toggle = (val: string) => {
+    if (selected.includes(val)) {
+      onChange(selected.filter((s) => s !== val))
+    } else if (selected.length < max) {
+      onChange([...selected, val])
+    }
+  }
+  return (
+    <fieldset className="flex flex-col gap-2">
+      <legend className="text-sm font-medium text-foreground mb-1">{label} (choose up to {max})</legend>
+      <div className="flex flex-wrap gap-2">
+        {options.map((opt) => {
+          const isSelected = selected.includes(opt)
+          return (
+            <button
+              key={opt}
+              type="button"
+              onClick={() => toggle(opt)}
+              className={`inline-flex items-center rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${
+                isSelected
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-border bg-secondary/50 text-muted-foreground hover:border-primary/50 hover:text-foreground"
+              }`}
+            >
+              {isSelected && <span className="mr-1.5">✓</span>}
+              {opt}
+            </button>
+          )
+        })}
+      </div>
+    </fieldset>
+  )
+}
+
+function SingleSelect({
+  options,
+  selected,
+  onChange,
+  label,
+}: {
+  options: readonly string[]
+  selected: string
+  onChange: (val: string) => void
+  label: string
+}) {
+  return (
+    <fieldset className="flex flex-col gap-2">
+      <legend className="text-sm font-medium text-foreground mb-1">{label}</legend>
+      <div className="flex flex-wrap gap-2">
+        {options.map((opt) => {
+          const isSelected = selected === opt
+          return (
+            <button
+              key={opt}
+              type="button"
+              onClick={() => onChange(opt)}
+              className={`inline-flex items-center rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${
+                isSelected
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-border bg-secondary/50 text-muted-foreground hover:border-primary/50 hover:text-foreground"
+              }`}
+            >
+              {isSelected && <span className="mr-1.5">●</span>}
+              {opt}
+            </button>
+          )
+        })}
+      </div>
+    </fieldset>
+  )
+}
+
+export function PersonaSurveyForm({ onSubmit, onUseTextarea, isPending, error }: PersonaSurveyFormProps) {
+  const [targetAudience, setTargetAudience] = useState("")
+  const [goals, setGoals] = useState<string[]>([])
+  const [frustration, setFrustration] = useState("")
+  const [currentSolution, setCurrentSolution] = useState("")
+  const [decisionFactors, setDecisionFactors] = useState<string[]>([])
+  const [audienceKnowledge, setAudienceKnowledge] = useState("")
+  const [decisionTypes, setDecisionTypes] = useState<string[]>([])
+  const [additionalNotes, setAdditionalNotes] = useState("")
+
+  const isComplete =
+    targetAudience.trim().length > 0 &&
+    goals.length > 0 &&
+    frustration.length > 0 &&
+    currentSolution.length > 0 &&
+    decisionFactors.length > 0 &&
+    audienceKnowledge.length > 0 &&
+    decisionTypes.length > 0
+
+  const handleSubmit = () => {
+    if (!isComplete) return
+    onSubmit({
+      targetAudience: targetAudience.trim(),
+      goals,
+      frustration,
+      currentSolution,
+      decisionFactors,
+      audienceKnowledge,
+      decisionTypes,
+      additionalNotes: additionalNotes.trim() || undefined,
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      {/* Question 1: Target audience */}
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium text-foreground">Who are you targeting?</label>
+        <p className="text-xs text-muted-foreground">Describe your audience in a few words.</p>
+        <input
+          type="text"
+          value={targetAudience}
+          onChange={(e) => setTargetAudience(e.target.value)}
+          placeholder="e.g. Small business owners, Frontend engineers, HR managers"
+          disabled={isPending}
+          className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+        />
+      </div>
+
+      {/* Question 2: Goals */}
+      <MultiSelect
+        options={GOAL_OPTIONS}
+        selected={goals}
+        onChange={setGoals}
+        max={3}
+        label="What are they trying to accomplish?"
+      />
+
+      {/* Question 3: Frustration */}
+      <SingleSelect
+        options={FRUSTRATION_OPTIONS}
+        selected={frustration}
+        onChange={setFrustration}
+        label="What is their biggest frustration?"
+      />
+
+      {/* Question 4: Current solution */}
+      <SingleSelect
+        options={SOLUTION_OPTIONS}
+        selected={currentSolution}
+        onChange={setCurrentSolution}
+        label="How do they solve this today?"
+      />
+
+      {/* Question 5: Decision factors */}
+      <MultiSelect
+        options={DECISION_FACTOR_OPTIONS}
+        selected={decisionFactors}
+        onChange={setDecisionFactors}
+        max={3}
+        label="What makes them choose a product?"
+      />
+
+      {/* Question 6: Audience knowledge */}
+      <SingleSelect
+        options={AUDIENCE_KNOWLEDGE_OPTIONS}
+        selected={audienceKnowledge}
+        onChange={setAudienceKnowledge}
+        label="How well do you know this audience?"
+      />
+
+      {/* Question 7: Decision types */}
+      <MultiSelect
+        options={DECISION_TYPE_OPTIONS}
+        selected={decisionTypes}
+        onChange={setDecisionTypes}
+        max={5}
+        label="What kind of decisions do you want these personas to help you evaluate?"
+      />
+
+      {/* Question 8: Additional notes (optional) */}
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium text-foreground">Anything else we should know? <span className="text-muted-foreground font-normal">(optional)</span></label>
+        <Textarea
+          value={additionalNotes}
+          onChange={(e) => setAdditionalNotes(e.target.value)}
+          placeholder="Any additional context about your audience..."
+          disabled={isPending}
+          className="min-h-[80px] resize-y"
+        />
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          onClick={onUseTextarea}
+          className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-4 transition-colors"
+        >
+          Use freeform description instead
+        </button>
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={!isComplete || isPending}
+          className="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-primary px-6 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
+        >
+          {isPending ? (
+            <>Generating...</>
+          ) : (
+            <>
+              Generate Personas
+              <SparklesIcon className="h-4 w-4" />
+            </>
+          )}
+        </button>
+      </div>
+
+      {error && (
+        <p className="text-sm text-destructive font-medium bg-destructive/10 p-3 rounded-md">{error}</p>
+      )}
+    </div>
+  )
+}

--- a/src/domain/dtos/PersonaGenerationConfig.ts
+++ b/src/domain/dtos/PersonaGenerationConfig.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+const BasePersonaConfigSchema = z.object({
+  count: z.number().int().min(1).max(10).describe("Number of personas to generate (1-10)"),
+  personaDescription: z.string().min(1).describe("Textual description of the target persona(s)"),
+  contextNotes: z.string().optional().describe("Additional context or notes for generation"),
+});
+
+export const ResearchPersonaConfigSchema = BasePersonaConfigSchema.extend({
+  interviewIds: z.array(z.string()).optional().describe("Interview transcript IDs to ground the personas"),
+  evidenceThreshold: z.number().min(0).max(1).optional().describe("Minimum confidence (0-1) to include an attribute"),
+  preserveUncertainty: z.boolean().optional().describe("Explicitly mark low-confidence attributes"),
+});
+
+export const StrategyPersonaConfigSchema = BasePersonaConfigSchema.extend({
+  icpDescription: z.string().optional().describe("Ideal Customer Profile description"),
+  allowSyntheticBackstory: z.boolean().optional().describe("Allow fabricated narrative details"),
+  storytellingLevel: z.enum(['conservative', 'moderate', 'rich']).optional().describe("Level of narrative enrichment"),
+});
+
+export const ClusterPersonaConfigSchema = BasePersonaConfigSchema.extend({
+  personaDescription: z.string().optional().describe("Optional description hint; derived from cluster if absent"),
+  interviewIds: z.array(z.string()).min(1).describe("Source interview IDs forming this cluster"),
+  clusterLabel: z.string().min(1).describe("Human-readable label for the cluster (e.g. 'Efficiency-focused engineers')"),
+  minClusterSize: z.number().int().min(1).describe("Minimum interview subjects required to form a cluster"),
+});
+
+export type ResearchPersonaConfig = z.infer<typeof ResearchPersonaConfigSchema>;
+export type StrategyPersonaConfig = z.infer<typeof StrategyPersonaConfigSchema>;
+export type ClusterPersonaConfig = z.infer<typeof ClusterPersonaConfigSchema>;

--- a/src/domain/dtos/__tests__/PersonaGenerationConfig.test.ts
+++ b/src/domain/dtos/__tests__/PersonaGenerationConfig.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ResearchPersonaConfigSchema,
+  StrategyPersonaConfigSchema,
+  ClusterPersonaConfigSchema,
+} from '../PersonaGenerationConfig'
+
+describe('ResearchPersonaConfig', () => {
+  it('should validate a valid research config', () => {
+    const result = ResearchPersonaConfigSchema.safeParse({
+      count: 3,
+      personaDescription: 'Junior backend engineers looking for jobs',
+      evidenceThreshold: 0.7,
+      preserveUncertainty: true,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should accept optional interviewIds', () => {
+    const result = ResearchPersonaConfigSchema.safeParse({
+      count: 3,
+      personaDescription: 'Test',
+      interviewIds: ['int-1', 'int-2'],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should reject evidenceThreshold outside 0-1', () => {
+    const result = ResearchPersonaConfigSchema.safeParse({
+      count: 3,
+      personaDescription: 'Test',
+      evidenceThreshold: 1.5,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject count above max', () => {
+    const result = ResearchPersonaConfigSchema.safeParse({
+      count: 11,
+      personaDescription: 'Test',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject count below min', () => {
+    const result = ResearchPersonaConfigSchema.safeParse({
+      count: 0,
+      personaDescription: 'Test',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject empty personaDescription', () => {
+    const result = ResearchPersonaConfigSchema.safeParse({
+      count: 3,
+      personaDescription: '',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('StrategyPersonaConfig', () => {
+  it('should validate a valid strategy config', () => {
+    const result = StrategyPersonaConfigSchema.safeParse({
+      count: 5,
+      personaDescription: 'Enterprise buyers',
+      allowSyntheticBackstory: true,
+      storytellingLevel: 'rich',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should accept all three storytelling levels', () => {
+    for (const level of ['conservative', 'moderate', 'rich'] as const) {
+      const result = StrategyPersonaConfigSchema.safeParse({
+        count: 3,
+        personaDescription: 'Test',
+        storytellingLevel: level,
+      })
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it('should reject invalid storytelling level', () => {
+    const result = StrategyPersonaConfigSchema.safeParse({
+      count: 3,
+      personaDescription: 'Test',
+      storytellingLevel: 'extreme',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('ClusterPersonaConfig', () => {
+  it('should validate a valid cluster config', () => {
+    const result = ClusterPersonaConfigSchema.safeParse({
+      count: 3,
+      personaDescription: 'Representative users',
+      interviewIds: ['int-1', 'int-2', 'int-3'],
+      clusterLabel: 'Efficiency-focused engineers',
+      minClusterSize: 5,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should allow optional personaDescription', () => {
+    const result = ClusterPersonaConfigSchema.safeParse({
+      count: 3,
+      interviewIds: ['int-1'],
+      clusterLabel: 'Test',
+      minClusterSize: 1,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should reject empty interviewIds', () => {
+    const result = ClusterPersonaConfigSchema.safeParse({
+      count: 3,
+      interviewIds: [],
+      clusterLabel: 'Test',
+      minClusterSize: 1,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject minClusterSize less than 1', () => {
+    const result = ClusterPersonaConfigSchema.safeParse({
+      count: 3,
+      interviewIds: ['int-1'],
+      clusterLabel: 'Test',
+      minClusterSize: 0,
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/domain/entities/BehavioralDimension.ts
+++ b/src/domain/entities/BehavioralDimension.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export interface BehavioralDimension {
+  name: string;
+  score: number;
+  context: string;
+  description: string;
+  evidence?: string;
+}
+
+export const BehavioralDimensionSchema = z.object({
+  name: z.string().min(1),
+  score: z.number().min(0).max(100),
+  context: z.string().min(1),
+  description: z.string().min(1),
+  evidence: z.string().optional(),
+});

--- a/src/domain/entities/Persona.ts
+++ b/src/domain/entities/Persona.ts
@@ -56,6 +56,8 @@ export interface Persona {
   // Psychographic Specification — Wang et al. (2024b) Section 3.1(2)
   values: string[];            // Core values that drive decisions
   fears: string[];             // Anxieties and risk concerns
+  valueEvidence?: string[];    // Evidence quotes for each value (parallel to values)
+  fearEvidence?: string[];     // Evidence quotes for each fear (parallel to fears)
   communicationStyle: string;  // How they speak (e.g. "direct", "analytical", "collaborative")
   decisionStyle: string;       // Decision process (e.g. "data-driven", "gut-driven", "consensus-seeking")
 
@@ -136,6 +138,8 @@ export const PersonaSchema = z.object({
   // Psychographic Specification
   values: z.array(z.string()).describe("Core values driving decisions"),
   fears: z.array(z.string()).describe("Anxieties and risk concerns"),
+  valueEvidence: z.array(z.string()).optional().describe("Evidence quotes for each value (parallel to values)"),
+  fearEvidence: z.array(z.string()).optional().describe("Evidence quotes for each fear (parallel to fears)"),
   communicationStyle: z.string().describe("How they speak — direct, analytical, collaborative, etc."),
   decisionStyle: z.string().describe("Decision process — data-driven, gut-driven, consensus-seeking, etc."),
 

--- a/src/domain/entities/Persona.ts
+++ b/src/domain/entities/Persona.ts
@@ -106,6 +106,15 @@ export interface Persona {
   // product decision be made?" Details that fail this test should not influence
   // product decisions.
   counterfactualTest?: string;
+
+  // Prediction scope: what this persona is good at / less reliable for
+  bestFor?: string[];
+  lessReliableFor?: string[];
+
+  // PB&J (Psychology of Behavior and Judgment) rationales — Joshi et al. (2025)
+  // Causal explanations connecting the persona's profile to their values, fears, and decisions.
+  // Displayed in the Advanced Model Details section, not in the backstory.
+  pbjRationales?: string;
 }
 
 export const PersonaSchema = z.object({
@@ -168,6 +177,12 @@ export const PersonaSchema = z.object({
     .describe("Contextual behavior specific to a domain"),
   counterfactualTest: z.string().optional()
     .describe("If this detail were false, would a different product decision be made?"),
+  bestFor: z.array(z.string()).optional()
+    .describe("What this persona model is good at predicting"),
+  lessReliableFor: z.array(z.string()).optional()
+    .describe("What this persona model is less reliable for"),
+  pbjRationales: z.string().optional()
+    .describe("PB&J rationales — causal explanations connecting the persona's profile to their values, fears, and decisions"),
 });
 
 export function validatePersona(entity: unknown): boolean {

--- a/src/domain/entities/Persona.ts
+++ b/src/domain/entities/Persona.ts
@@ -1,4 +1,18 @@
 import { z } from "zod";
+import type {
+  PersonaProvenance,
+  EvidenceLink,
+  ClusterInfo,
+  PersonaGenerationMode,
+} from "./PersonaProvenance";
+import type { BehavioralDimension } from "./BehavioralDimension";
+import {
+  PersonaProvenanceSchema,
+  PersonaGenerationModeSchema,
+  EvidenceLinkSchema,
+  ClusterInfoSchema,
+} from "./PersonaProvenance";
+import { BehavioralDimensionSchema } from "./BehavioralDimension";
 
 /**
  * Persona entity — grounded in the inference-time persona construction literature.
@@ -17,6 +31,11 @@ import { z } from "zod";
  * - cognitiveReflex (System 1/2): not a validated psychometric construct
  * - technicalFluency, economicSensitivity: not standard psychometric dimensions
  * - designStyle, livingEnvironment: narrative details → backstory
+ *
+ * Generation modes (2025 philosophy):
+ * - research: evidence-first, minimal invention, no fabricated memories
+ * - strategy: richer storytelling, representative assumptions, optimized for imagination
+ * - cluster: synthetic representative from multiple interview signals
  */
 export interface Persona {
   id: string;
@@ -57,6 +76,36 @@ export interface Persona {
 
   // Variant tracking — set when this persona was generated as a variant of another
   variantOf?: { id: string; name: string };
+
+  // --- Persona Modeling Philosophy (2025) ---
+
+  // Generation mode: how this persona was created
+  generationMode?: PersonaGenerationMode;
+
+  // Behavioral dimensions: domain-specific axes (contextual, not universal traits)
+  // Supplements the universal Big Five with contextual behavioral dimensions.
+  // Example: "friction-tolerance" in job search context, not general personality.
+  behavioralDimensions?: BehavioralDimension[];
+
+  // Provenance tracking: per-attribute confidence and tier labeling
+  provenance?: PersonaProvenance;
+
+  // Evidence links: direct interview/source excerpts backing persona attributes
+  evidenceLinks?: EvidenceLink[];
+
+  // Cluster info: for personas representing a group of interview subjects
+  clusterInfo?: ClusterInfo;
+
+  // Identity vs situation distinction:
+  // identityContext = stable traits (applies across domains)
+  // situationContext = contextual behavior (domain-specific)
+  identityContext?: string;
+  situationContext?: string;
+
+  // Counterfactual removal test: "If this detail were false, would a different
+  // product decision be made?" Details that fail this test should not influence
+  // product decisions.
+  counterfactualTest?: string;
 }
 
 export const PersonaSchema = z.object({
@@ -95,47 +144,131 @@ export const PersonaSchema = z.object({
 
   // Narrative
   backstory: z.string().optional().describe("Life narrative — causally coherent backstory (Moon 2024)"),
+
+  // Variant tracking
+  variantOf: z.object({
+    id: z.string(),
+    name: z.string(),
+  }).optional().describe("Reference to source persona when this is a variant"),
+
+  // --- Persona Modeling Philosophy (2025) ---
+  generationMode: PersonaGenerationModeSchema.optional()
+    .describe("How this persona was created: research, strategy, or cluster"),
+  behavioralDimensions: z.array(BehavioralDimensionSchema).optional()
+    .describe("Domain-specific behavioral axes (contextual, not universal traits)"),
+  provenance: PersonaProvenanceSchema.optional()
+    .describe("Per-attribute confidence and tier labeling"),
+  evidenceLinks: z.array(EvidenceLinkSchema).optional()
+    .describe("Direct interview/source excerpts backing persona attributes"),
+  clusterInfo: ClusterInfoSchema.optional()
+    .describe("Cluster info for personas representing a group of interview subjects"),
+  identityContext: z.string().optional()
+    .describe("Stable traits that apply across domains"),
+  situationContext: z.string().optional()
+    .describe("Contextual behavior specific to a domain"),
+  counterfactualTest: z.string().optional()
+    .describe("If this detail were false, would a different product decision be made?"),
 });
 
-export function validatePersona(entity: Persona): boolean {
-  return !!entity.id;
+export function validatePersona(entity: unknown): boolean {
+  if (!entity || typeof entity !== 'object') return false;
+  return PersonaSchema.safeParse(entity).success;
 }
 
-export function stringifyPersona(entity: Persona): string {
-  const join = (arr?: string[]) => (arr && arr.length ? arr.join(", ") : "—");
-  const normalize = (text?: string) => (text ? text.replace(/\s+/g, " ").trim() : undefined);
+export function stringifyPersona(entity: unknown): string {
+  if (!entity || typeof entity !== 'object') return "—";
+  const p = entity as Record<string, unknown>;
+  const str = (val: unknown): string => (val != null && val !== "" ? String(val) : "—");
+  const join = (arr?: unknown) =>
+    Array.isArray(arr) && arr.length > 0 ? arr.map(String).join(", ") : "—";
+  const normalize = (text?: unknown) =>
+    typeof text === "string" ? text.replace(/\s+/g, " ").trim() : undefined;
 
   const lines: string[] = [
-    `Name: ${entity.name ?? "—"}`,
-    `Age: ${entity.age ?? "—"}`,
-    `Occupation: ${entity.occupation ?? "—"}`,
-    `Education: ${entity.educationLevel ?? "—"}`,
-    `Interests: ${join(entity.interests)}`,
-    `Goals: ${join(entity.goals)}`,
+    `Name: ${str(p.name)}`,
+    `Age: ${str(p.age)}`,
+    `Occupation: ${str(p.occupation)}`,
+    `Education: ${str(p.educationLevel)}`,
+    `Interests: ${join(p.interests)}`,
+    `Goals: ${join(p.goals)}`,
     `--- BIG FIVE (0-100) ---`,
-    `Conscientiousness: ${entity.conscientiousness ?? 50} (Low=Chaotic, High=Meticulous)`,
-    `Neuroticism: ${entity.neuroticism ?? 50} (Low=Stable, High=Anxious/Risk-Averse)`,
-    `Openness: ${entity.openness ?? 50} (Low=Traditional, High=Early Adopter)`,
-    `Extraversion: ${entity.extraversion ?? 50} (Low=Solitary, High=Outgoing)`,
-    `Agreeableness: ${entity.agreeableness ?? 50} (Low=Competitive, High=Compassionate)`,
+    `Conscientiousness: ${str(p.conscientiousness)} (Low=Chaotic, High=Meticulous)`,
+    `Neuroticism: ${str(p.neuroticism)} (Low=Stable, High=Anxious/Risk-Averse)`,
+    `Openness: ${str(p.openness)} (Low=Traditional, High=Early Adopter)`,
+    `Extraversion: ${str(p.extraversion)} (Low=Solitary, High=Outgoing)`,
+    `Agreeableness: ${str(p.agreeableness)} (Low=Competitive, High=Compassionate)`,
     `--- PSYCHOGRAPHIC SPECIFICATION ---`,
-    `Values: ${join(entity.values)}`,
-    `Fears: ${join(entity.fears)}`,
-    `Communication Style: ${entity.communicationStyle ?? "—"}`,
-    `Decision Style: ${entity.decisionStyle ?? "—"}`,
-    `Pricing Sensitivity: ${entity.pricingSensitivity ?? 50}/100`,
-    `Typical Budget: ${entity.typicalBudget ?? "—"}`,
+    `Values: ${join(p.values)}`,
+    `Fears: ${join(p.fears)}`,
+    `Communication Style: ${str(p.communicationStyle)}`,
+    `Decision Style: ${str(p.decisionStyle)}`,
+    `Pricing Sensitivity: ${str(p.pricingSensitivity)}/100`,
+    `Typical Budget: ${str(p.typicalBudget)}`,
   ];
 
   // Epistemic boundaries
-  const expertise = join(entity.domainExpertise);
+  const expertise = join(p.domainExpertise);
   if (expertise && expertise !== "—") lines.push(`Domain Expertise: ${expertise}`);
-  const boundaries = join(entity.epistemicBoundaries);
+  const boundaries = join(p.epistemicBoundaries);
   if (boundaries && boundaries !== "—") lines.push(`Epistemic Boundaries: ${boundaries}`);
 
   // Narrative
-  const backstory = normalize(entity.backstory);
+  const backstory = normalize(p.backstory);
   if (backstory) lines.push(`Backstory: ${backstory}`);
+
+  // Generation mode
+  if (p.generationMode) lines.push(`Generation Mode: ${p.generationMode}`);
+
+  // Behavioral dimensions
+  if (Array.isArray(p.behavioralDimensions) && p.behavioralDimensions.length > 0) {
+    lines.push(`--- BEHAVIORAL DIMENSIONS ---`);
+    for (const dim of p.behavioralDimensions) {
+      const d = dim as Record<string, unknown>;
+      lines.push(`${d.name}: ${d.score}/100 (${d.context}) — ${d.description}`);
+    }
+  }
+
+  // Provenance
+  if (p.provenance) {
+    const prov = p.provenance as Record<string, unknown>;
+    lines.push(`--- PROVENANCE ---`);
+    lines.push(`Overall Confidence: ${prov.overallConfidence}`);
+    lines.push(`Generation Mode: ${prov.generationMode}`);
+    lines.push(`Attribute Provenance:`);
+    if (Array.isArray(prov.attributes)) {
+      for (const attr of prov.attributes) {
+        const a = attr as Record<string, unknown>;
+        lines.push(`  ${a.attribute}: tier=${a.tier}, confidence=${a.confidence}`);
+      }
+    }
+  }
+
+  // Evidence links
+  if (Array.isArray(p.evidenceLinks) && p.evidenceLinks.length > 0) {
+    lines.push(`--- EVIDENCE LINKS ---`);
+    for (const link of p.evidenceLinks) {
+      const l = link as Record<string, unknown>;
+      lines.push(`${l.attribute}: "${l.excerpt}" (${l.transcriptId})`);
+    }
+  }
+
+  // Cluster info
+  if (p.clusterInfo) {
+    const ci = p.clusterInfo as Record<string, unknown>;
+    lines.push(`--- CLUSTER INFO ---`);
+    lines.push(`Representing ${ci.representedCount} interview subjects`);
+    if (Array.isArray(ci.sourceIds)) lines.push(`Sources: ${ci.sourceIds.join(", ")}`);
+  }
+
+  // Identity/Situation context
+  const identityContext = normalize(p.identityContext);
+  if (identityContext) lines.push(`Identity Context: ${identityContext}`);
+  const situationContext = normalize(p.situationContext);
+  if (situationContext) lines.push(`Situation Context: ${situationContext}`);
+
+  // Counterfactual test
+  const counterfactualTest = normalize(p.counterfactualTest);
+  if (counterfactualTest) lines.push(`Counterfactual Test: ${counterfactualTest}`);
 
   return lines.join("\n");
 }

--- a/src/domain/entities/PersonaProvenance.ts
+++ b/src/domain/entities/PersonaProvenance.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+
+export type TierLabel = 'observed' | 'interpreted' | 'synthetic';
+
+export type PersonaGenerationMode = 'research' | 'strategy' | 'cluster';
+
+export interface AttributeProvenance {
+  attribute: string;
+  tier: TierLabel;
+  confidence: number;
+  evidence?: string;
+  source?: string;
+}
+
+export interface PersonaProvenance {
+  attributes: AttributeProvenance[];
+  generationMode: PersonaGenerationMode;
+  overallConfidence: number;
+}
+
+export interface EvidenceLink {
+  transcriptId: string;
+  excerpt: string;
+  attribute: string;
+  timestamp?: string;
+}
+
+export interface ClusterInfo {
+  representedCount: number;
+  sourceIds: string[];
+  confidenceInterval?: string;
+}
+
+export const TierLabelSchema = z.enum(['observed', 'interpreted', 'synthetic']);
+
+export const PersonaGenerationModeSchema = z.enum(['research', 'strategy', 'cluster']);
+
+export const AttributeProvenanceSchema = z.object({
+  attribute: z.string().min(1),
+  tier: TierLabelSchema,
+  confidence: z.number().min(0).max(1),
+  evidence: z.string().optional(),
+  source: z.string().optional(),
+});
+
+export const PersonaProvenanceSchema = z.object({
+  attributes: z.array(AttributeProvenanceSchema),
+  generationMode: PersonaGenerationModeSchema,
+  overallConfidence: z.number().min(0).max(1),
+});
+
+export const EvidenceLinkSchema = z.object({
+  transcriptId: z.string().min(1),
+  excerpt: z.string().min(1),
+  attribute: z.string().min(1),
+  timestamp: z.string().optional(),
+});
+
+export const ClusterInfoSchema = z.object({
+  representedCount: z.number().int().min(1),
+  sourceIds: z.array(z.string()).min(1),
+  confidenceInterval: z.string().optional(),
+});

--- a/src/domain/entities/__tests__/BehavioralDimension.test.ts
+++ b/src/domain/entities/__tests__/BehavioralDimension.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { BehavioralDimensionSchema } from '../BehavioralDimension'
+
+describe('BehavioralDimension', () => {
+  it('should validate a correct behavioral dimension', () => {
+    const dim = {
+      name: 'friction-tolerance',
+      score: 85,
+      context: 'job search behavior',
+      description: 'Tolerance for unnecessary workflow steps',
+    }
+    const result = BehavioralDimensionSchema.safeParse(dim)
+    expect(result.success).toBe(true)
+  })
+
+  it('should reject score outside 0-100 range', () => {
+    const dim = {
+      name: 'friction-tolerance',
+      score: 150,
+      context: 'job search behavior',
+      description: 'Tolerance for unnecessary workflow steps',
+    }
+    const result = BehavioralDimensionSchema.safeParse(dim)
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject negative score', () => {
+    const dim = {
+      name: 'friction-tolerance',
+      score: -10,
+      context: 'job search behavior',
+      description: 'Tolerance for unnecessary workflow steps',
+    }
+    const result = BehavioralDimensionSchema.safeParse(dim)
+    expect(result.success).toBe(false)
+  })
+
+  it('should accept optional evidence field', () => {
+    const dim = {
+      name: 'automation-preference',
+      score: 90,
+      context: 'job search behavior',
+      description: 'Preference for automated repetitive tasks',
+      evidence: 'User stated "I think Jobright makes it easier"',
+    }
+    const result = BehavioralDimensionSchema.safeParse(dim)
+    expect(result.success).toBe(true)
+  })
+
+  it('should require name, score, context, and description', () => {
+    const result = BehavioralDimensionSchema.safeParse({
+      name: 'test',
+      score: 50,
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/domain/entities/__tests__/Persona.test.ts
+++ b/src/domain/entities/__tests__/Persona.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { validatePersona, stringifyPersona } from '../Persona'
 
 describe('Persona entity', () => {
-  const mockPersona = {
+  const validPersona = {
     id: '1',
     name: 'Test Persona',
     age: 30,
@@ -10,18 +10,53 @@ describe('Persona entity', () => {
     educationLevel: 'Bachelors',
     interests: ['coding'],
     goals: ['learning'],
-    personalityTraits: ['logical'],
-    backstory: 'A test backstory'
+    conscientiousness: 70,
+    neuroticism: 40,
+    openness: 80,
+    extraversion: 30,
+    agreeableness: 50,
+    values: ['Efficiency'],
+    fears: ['Wasted effort'],
+    communicationStyle: 'Direct',
+    decisionStyle: 'Data-driven',
+    pricingSensitivity: 60,
+    typicalBudget: 'Up to $20/user/month',
+    backstory: 'A test backstory',
   }
 
   it('should validate a correct persona', () => {
-    expect(validatePersona(mockPersona)).toBe(true)
+    expect(validatePersona(validPersona)).toBe(true)
+  })
+
+  it('should reject null entity', () => {
+    expect(validatePersona(null)).toBe(false)
+  })
+
+  it('should reject undefined entity', () => {
+    expect(validatePersona(undefined)).toBe(false)
+  })
+
+  it('should reject empty object', () => {
+    expect(validatePersona({})).toBe(false)
   })
 
   it('should stringify a persona correctly', () => {
-    const str = stringifyPersona(mockPersona)
+    const str = stringifyPersona(validPersona)
     expect(str).toContain('Name: Test Persona')
     expect(str).toContain('Age: 30')
     expect(str).toContain('A test backstory')
+  })
+
+  it('stringifyPersona should handle null', () => {
+    expect(stringifyPersona(null)).toBe('—')
+  })
+
+  it('stringifyPersona should handle undefined', () => {
+    expect(stringifyPersona(undefined)).toBe('—')
+  })
+
+  it('stringifyPersona should handle empty object', () => {
+    const str = stringifyPersona({})
+    expect(str).toContain('Name: —')
   })
 })

--- a/src/domain/entities/__tests__/PersonaNewFields.test.ts
+++ b/src/domain/entities/__tests__/PersonaNewFields.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest'
+import { PersonaSchema, stringifyPersona, validatePersona } from '../Persona'
+import { BehavioralDimensionSchema } from '../BehavioralDimension'
+import { PersonaProvenanceSchema } from '../PersonaProvenance'
+
+describe('Persona new fields', () => {
+  const basePersona = {
+    id: 'test-1',
+    name: 'Sawyer Miller',
+    age: 24,
+    occupation: 'Junior Backend Engineer',
+    educationLevel: 'B.S. Computer Science',
+    interests: ['automation', 'scripting'],
+    goals: ['Find a backend role', 'Reduce job search friction'],
+    conscientiousness: 70,
+    neuroticism: 40,
+    openness: 80,
+    extraversion: 30,
+    agreeableness: 50,
+    values: ['Efficiency', 'Transparency'],
+    fears: ['Wasted effort', 'Outdated job postings'],
+    communicationStyle: 'Direct',
+    decisionStyle: 'Data-driven',
+    pricingSensitivity: 60,
+    typicalBudget: 'Up to $20/user/month',
+  }
+
+  it('should accept all three generationModes', () => {
+    for (const mode of ['research', 'strategy', 'cluster'] as const) {
+      const persona = {
+        ...basePersona,
+        generationMode: mode,
+        behavioralDimensions: [],
+        provenance: {
+          attributes: [],
+          generationMode: mode,
+          overallConfidence: 0.5,
+        },
+        evidenceLinks: [],
+      }
+      const result = PersonaSchema.safeParse(persona)
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it('should validate behavioralDimensions within persona', () => {
+    const persona = {
+      ...basePersona,
+      generationMode: 'research' as const,
+      behavioralDimensions: [
+        {
+          name: 'friction-tolerance',
+          score: 85,
+          context: 'job search behavior',
+          description: 'Tolerance for unnecessary workflow steps',
+          evidence: 'User said "extra clicks add friction"',
+        },
+        {
+          name: 'recency-sensitivity',
+          score: 90,
+          context: 'job search behavior',
+          description: 'Preference for recently posted opportunities',
+          evidence: 'User said "these are from two weeks ago"',
+        },
+      ],
+      provenance: {
+        attributes: [
+          { attribute: 'friction-tolerance', tier: 'observed' as const, confidence: 0.9, evidence: 'Direct quote' },
+          { attribute: 'recency-sensitivity', tier: 'observed' as const, confidence: 0.9, evidence: 'Direct quote' },
+        ],
+        generationMode: 'research' as const,
+        overallConfidence: 0.9,
+      },
+      evidenceLinks: [],
+    }
+    const result = PersonaSchema.safeParse(persona)
+    expect(result.success).toBe(true)
+  })
+
+  it('should reject invalid generationMode', () => {
+    const persona = {
+      ...basePersona,
+      generationMode: 'invalid-mode',
+      behavioralDimensions: [],
+      provenance: { attributes: [], generationMode: 'research' as const, overallConfidence: 0.5 },
+      evidenceLinks: [],
+    }
+    const result = PersonaSchema.safeParse(persona)
+    expect(result.success).toBe(false)
+  })
+
+  it('should validate evidenceLinks', () => {
+    const persona = {
+      ...basePersona,
+      generationMode: 'research' as const,
+      behavioralDimensions: [],
+      provenance: {
+        attributes: [{ attribute: 'goals', tier: 'observed' as const, confidence: 0.95 }],
+        generationMode: 'research' as const,
+        overallConfidence: 0.95,
+      },
+      evidenceLinks: [
+        {
+          transcriptId: 'interview-1',
+          excerpt: 'I think Jobright makes it easier',
+          attribute: 'automation-preference',
+        },
+      ],
+    }
+    const result = PersonaSchema.safeParse(persona)
+    expect(result.success).toBe(true)
+  })
+
+  it('should validate clusterInfo', () => {
+    const persona = {
+      ...basePersona,
+      generationMode: 'cluster' as const,
+      behavioralDimensions: [],
+      provenance: {
+        attributes: [],
+        generationMode: 'cluster' as const,
+        overallConfidence: 0.6,
+      },
+      evidenceLinks: [],
+      clusterInfo: {
+        representedCount: 8,
+        sourceIds: ['interview-1', 'interview-2', 'interview-3'],
+      },
+    }
+    const result = PersonaSchema.safeParse(persona)
+    expect(result.success).toBe(true)
+  })
+
+  it('should validate identityContext and situationContext', () => {
+    const persona = {
+      ...basePersona,
+      generationMode: 'research' as const,
+      behavioralDimensions: [],
+      provenance: {
+        attributes: [],
+        generationMode: 'research' as const,
+        overallConfidence: 0.5,
+      },
+      evidenceLinks: [],
+      identityContext: 'Friction-averse in tool evaluation across all domains',
+      situationContext: 'Recency-obsessed specifically during active job search',
+    }
+    const result = PersonaSchema.safeParse(persona)
+    expect(result.success).toBe(true)
+  })
+
+  it('should validate counterfactualTest', () => {
+    const persona = {
+      ...basePersona,
+      generationMode: 'strategy' as const,
+      behavioralDimensions: [],
+      provenance: {
+        attributes: [],
+        generationMode: 'strategy' as const,
+        overallConfidence: 0.5,
+      },
+      evidenceLinks: [],
+      counterfactualTest: 'If the backstory detail about Jobright usage were false, would the automation-preference dimension change?',
+    }
+    const result = PersonaSchema.safeParse(persona)
+    expect(result.success).toBe(true)
+  })
+
+  it('stringifyPersona should handle new fields', () => {
+    const persona = {
+      ...basePersona,
+      generationMode: 'research' as const,
+      behavioralDimensions: [
+        {
+          name: 'friction-tolerance',
+          score: 85,
+          context: 'job search behavior',
+          description: 'Tolerance for unnecessary steps',
+        },
+      ],
+      provenance: {
+        attributes: [
+          { attribute: 'friction-tolerance', tier: 'observed' as const, confidence: 0.9, evidence: 'Quotes' },
+        ],
+        generationMode: 'research' as const,
+        overallConfidence: 0.9,
+      },
+      evidenceLinks: [],
+      identityContext: 'Friction-averse',
+      counterfactualTest: 'Test description',
+    }
+    const str = stringifyPersona(persona)
+    expect(str).toContain('research')
+    expect(str).toContain('friction-tolerance')
+    expect(str).toContain('Friction-averse')
+    expect(str).toContain('Test description')
+  })
+
+  it('should pass schema validation for personas with all new fields populated', () => {
+    const persona = {
+      ...basePersona,
+      generationMode: 'research' as const,
+      behavioralDimensions: [],
+      provenance: {
+        attributes: [],
+        generationMode: 'research' as const,
+        overallConfidence: 0.5,
+      },
+      evidenceLinks: [],
+    }
+    const result = PersonaSchema.safeParse(persona)
+    expect(result.success).toBe(true)
+  })
+
+  it('should be backward compatible with old persona shape (no new fields)', () => {
+    const result = PersonaSchema.safeParse(basePersona)
+    expect(result.success).toBe(true)
+  })
+})

--- a/src/domain/entities/__tests__/PersonaProvenance.test.ts
+++ b/src/domain/entities/__tests__/PersonaProvenance.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { PersonaProvenanceSchema, TierLabel } from '../PersonaProvenance'
+
+describe('PersonaProvenance', () => {
+  it('should validate a correct provenance with tier labels', () => {
+    const provenance = {
+      attributes: [
+        { attribute: 'values', tier: 'observed' as TierLabel, confidence: 0.95, evidence: 'User said "I value transparency"' },
+        { attribute: 'personality', tier: 'interpreted' as TierLabel, confidence: 0.7 },
+        { attribute: 'backstory', tier: 'synthetic' as TierLabel, confidence: 0.5 },
+      ],
+      generationMode: 'research',
+      overallConfidence: 0.72,
+    }
+    const result = PersonaProvenanceSchema.safeParse(provenance)
+    expect(result.success).toBe(true)
+  })
+
+  it('should reject invalid tier label', () => {
+    const provenance = {
+      attributes: [
+        { attribute: 'values', tier: 'invented', confidence: 0.5 },
+      ],
+      generationMode: 'research',
+      overallConfidence: 0.5,
+    }
+    const result = PersonaProvenanceSchema.safeParse(provenance)
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject confidence outside 0-1 range', () => {
+    const provenance = {
+      attributes: [
+        { attribute: 'values', tier: 'observed' as TierLabel, confidence: 1.5 },
+      ],
+      generationMode: 'research',
+      overallConfidence: 1.5,
+    }
+    const result = PersonaProvenanceSchema.safeParse(provenance)
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject invalid generationMode', () => {
+    const provenance = {
+      attributes: [
+        { attribute: 'values', tier: 'observed' as TierLabel, confidence: 0.9 },
+      ],
+      generationMode: 'invalid-mode',
+      overallConfidence: 0.9,
+    }
+    const result = PersonaProvenanceSchema.safeParse(provenance)
+    expect(result.success).toBe(false)
+  })
+
+  it('should accept all three generation modes', () => {
+    for (const mode of ['research', 'strategy', 'cluster'] as const) {
+      const provenance = {
+        attributes: [],
+        generationMode: mode,
+        overallConfidence: 0.5,
+      }
+      const result = PersonaProvenanceSchema.safeParse(provenance)
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it('should accept optional source field on attributes', () => {
+    const provenance = {
+      attributes: [
+        {
+          attribute: 'values',
+          tier: 'observed' as TierLabel,
+          confidence: 0.9,
+          source: 'transcript',
+          evidence: 'Direct quote from interview',
+        },
+      ],
+      generationMode: 'research',
+      overallConfidence: 0.9,
+    }
+    const result = PersonaProvenanceSchema.safeParse(provenance)
+    expect(result.success).toBe(true)
+  })
+})

--- a/src/domain/ports/LlmServicePort.ts
+++ b/src/domain/ports/LlmServicePort.ts
@@ -2,6 +2,7 @@ import { Persona } from "../entities/Persona";
 import { PricingAnalysis } from "../entities/PricingAnalysis";
 import { StreamOfConsciousness } from "../entities/StreamOfConsciousness";
 import { ExtractedInterviewSignals } from "@/application/interviewPipeline/types";
+import type { ResearchPersonaConfig, StrategyPersonaConfig, ClusterPersonaConfig } from "../dtos/PersonaGenerationConfig";
 
 export type AgentAction =
     | { type: "CLICK"; selector: string; reasoning: string }
@@ -285,5 +286,41 @@ export interface LlmServicePort {
         communicationStyle: string;
         decisionStyle: string;
     }>;
+
+    // --- Dual-Mode Persona Generation (2025 Philosophy) ---
+
+    /**
+     * Research Mode: evidence-first persona generation from interview transcripts.
+     * Produces personas with provenance tracking, minimal invention, no fabricated memories.
+     */
+    generateResearchPersonas(config: ResearchPersonaConfig): Promise<Persona[]>;
+
+    /**
+     * Research Mode streaming variant.
+     */
+    generateResearchPersonasStream(config: ResearchPersonaConfig): AsyncIterable<Partial<Persona>[]>;
+
+    /**
+     * Strategy Mode: richer storytelling persona generation from ICP/market descriptions.
+     * Representative assumptions allowed for imagination and decision-making.
+     */
+    generateStrategyPersonas(config: StrategyPersonaConfig): Promise<Persona[]>;
+
+    /**
+     * Strategy Mode streaming variant.
+     */
+    generateStrategyPersonasStream(config: StrategyPersonaConfig): AsyncIterable<Partial<Persona>[]>;
+
+    /**
+     * Cluster Mode: synthetic representative personas from multiple interview signals.
+     * Produces labeled cluster personas with source references.
+     */
+    generateClusterPersonas(config: ClusterPersonaConfig): Promise<Persona[]>;
+
+    /**
+     * Counterfactual test: checks whether synthetic persona details would change
+     * product decisions. Details that fail this test should not influence decisions.
+     */
+    applyCounterfactualTest(persona: Persona): Promise<{ detail: string; reason: string; attribute?: string }[]>;
 }
 

--- a/src/infrastructure/adapters/LlmServiceImpl.ts
+++ b/src/infrastructure/adapters/LlmServiceImpl.ts
@@ -13,6 +13,7 @@ import { PricingAnalysis } from "@/domain/entities/PricingAnalysis";
 import { StreamOfConsciousness } from "@/domain/entities/StreamOfConsciousness";
 import { ExtractedInterviewSignals } from "@/application/interviewPipeline/types";
 import { AnalysisLogger } from "@/infrastructure/AnalysisLogger";
+import type { ResearchPersonaConfig, StrategyPersonaConfig, ClusterPersonaConfig } from "@/domain/dtos/PersonaGenerationConfig";
 
 export class LlmServiceImpl implements LlmServicePort {
   public client: OpenAI;
@@ -449,6 +450,32 @@ export class LlmServiceImpl implements LlmServicePort {
 
   async inferTraitsFromBackstory(backstory: string) {
     return this.personaAdapter.inferTraitsFromBackstory(backstory);
+  }
+
+  // --- Dual-Mode Persona Generation (2025 Philosophy) ---
+
+  async generateResearchPersonas(config: ResearchPersonaConfig): Promise<Persona[]> {
+    return this.personaAdapter.generateResearchPersonas(config);
+  }
+
+  async *generateResearchPersonasStream(config: ResearchPersonaConfig): AsyncIterable<Partial<Persona>[]> {
+    yield* this.personaAdapter.generateResearchPersonasStream(config);
+  }
+
+  async generateStrategyPersonas(config: StrategyPersonaConfig): Promise<Persona[]> {
+    return this.personaAdapter.generateStrategyPersonas(config);
+  }
+
+  async *generateStrategyPersonasStream(config: StrategyPersonaConfig): AsyncIterable<Partial<Persona>[]> {
+    yield* this.personaAdapter.generateStrategyPersonasStream(config);
+  }
+
+  async generateClusterPersonas(config: ClusterPersonaConfig): Promise<Persona[]> {
+    return this.personaAdapter.generateClusterPersonas(config);
+  }
+
+  async applyCounterfactualTest(persona: Persona): Promise<{ detail: string; reason: string; attribute?: string }[]> {
+    return this.personaAdapter.applyCounterfactualTest(persona);
   }
 
   async rationalizePersonas(personas: Persona[], contextNotes?: string): Promise<Persona[]> {

--- a/src/infrastructure/adapters/PersonaAdapter.ts
+++ b/src/infrastructure/adapters/PersonaAdapter.ts
@@ -276,6 +276,21 @@ Return ONLY valid JSON without explanatory text or markdown code blocks.`;
             backstory: (p.backstory as string) ?? (p.story as string) ?? undefined,
             generationMode: 'strategy' as const,
             behavioralDimensions: Array.isArray(p.behavioralDimensions) ? (p.behavioralDimensions as any) : [],
+            evidenceLinks: [{
+              transcriptId: 'user-input',
+              excerpt: personaDescription.length > 200 ? personaDescription.slice(0, 200) + "..." : personaDescription,
+              attribute: 'persona-description',
+            }],
+            provenance: {
+              attributes: [
+                { attribute: 'values', tier: 'interpreted' as const, confidence: 0.7 },
+                { attribute: 'fears', tier: 'interpreted' as const, confidence: 0.7 },
+                { attribute: 'goals', tier: 'interpreted' as const, confidence: 0.7 },
+                { attribute: 'backstory', tier: 'synthetic' as const, confidence: 0.5 },
+              ],
+              generationMode: 'strategy' as const,
+              overallConfidence: 0.7,
+            },
           }) as Persona,
       );
     } catch (err) {
@@ -968,11 +983,29 @@ ${config.contextNotes ? `Additional context: ${config.contextNotes}` : ""}`;
       );
 
       const records = PersonaAdapter.parsePersonaList(content, config.count, "strategy");
+      const evidenceExcerpt = config.personaDescription.length > 200
+        ? config.personaDescription.slice(0, 200) + "..."
+        : config.personaDescription;
       return records.map((p, idx) => ({
         ...PersonaAdapter.extractBaseFields(p),
         id: `strategy-persona-${idx}`,
         generationMode: "strategy" as const,
         behavioralDimensions: PersonaAdapter.extractBehavioralDimensions(p),
+        evidenceLinks: [{
+          transcriptId: 'user-input',
+          excerpt: evidenceExcerpt,
+          attribute: 'persona-description',
+        }],
+        provenance: {
+          attributes: [
+            { attribute: 'values', tier: 'interpreted' as const, confidence: 0.7 },
+            { attribute: 'fears', tier: 'interpreted' as const, confidence: 0.7 },
+            { attribute: 'goals', tier: 'interpreted' as const, confidence: 0.7 },
+            { attribute: 'backstory', tier: 'synthetic' as const, confidence: 0.5 },
+          ],
+          generationMode: 'strategy' as const,
+          overallConfidence: 0.7,
+        },
       })) as Persona[];
     } catch (err) {
       throw new Error(

--- a/src/infrastructure/adapters/PersonaAdapter.ts
+++ b/src/infrastructure/adapters/PersonaAdapter.ts
@@ -280,7 +280,7 @@ Return ONLY valid JSON without explanatory text or markdown code blocks.`;
 
             backstory: (p.backstory as string) ?? (p.story as string) ?? undefined,
             generationMode: 'strategy' as const,
-            behavioralDimensions: Array.isArray(p.behavioralDimensions) ? (p.behavioralDimensions as any) : [],
+            behavioralDimensions: PersonaAdapter.extractBehavioralDimensions(p),
             evidenceLinks: [{
               transcriptId: 'user-input',
               excerpt: personaDescription.length > 200 ? personaDescription.slice(0, 200) + "..." : personaDescription,
@@ -751,7 +751,7 @@ Return ONLY valid JSON array without explanatory text or markdown code blocks.`;
             domainExpertise: Array.isArray(p.domainExpertise) ? (p.domainExpertise as string[]) : [],
             backstory: (p.backstory as string) ?? "",
             generationMode: 'strategy' as const,
-            behavioralDimensions: Array.isArray(p.behavioralDimensions) ? (p.behavioralDimensions as any) : [],
+            behavioralDimensions: PersonaAdapter.extractBehavioralDimensions(p),
           }      ) as Persona,
       );
     } catch (err) {

--- a/src/infrastructure/adapters/PersonaAdapter.ts
+++ b/src/infrastructure/adapters/PersonaAdapter.ts
@@ -947,11 +947,12 @@ Base all backstory details on the provided evidence. Do not fabricate events.`;
     const system = `You are a research-grade persona generator. Base all claims on evidence. Do NOT fabricate specific life events or trauma.
 Generate a JSON array of ${personaCount} personas. Backstories should be rich narratives (6-10 paragraphs), evidence-based.`;
 
+    const streamUser = `Generate ${personaCount} research-mode personas for: "${config.personaDescription}". Evidence-first, no fabricated memories.${config.interviewIds ? ` Base on interview IDs: ${config.interviewIds.join(", ")}` : ""}${config.evidenceThreshold ? ` Minimum evidence confidence threshold: ${config.evidenceThreshold}` : ""}${config.contextNotes ? `\nAdditional context: ${config.contextNotes}` : ""}`;
     const { partialOutputStream } = streamText({
       model: this.llmService.provider(this.llmService.smallTextModel),
       output: Output.array({ element: PersonaSchema }),
       system,
-      prompt: `Generate ${personaCount} research-mode personas for: "${config.personaDescription}". Evidence-first, no fabricated memories.`,
+      prompt: streamUser,
     });
 
     if (!partialOutputStream) {

--- a/src/infrastructure/adapters/PersonaAdapter.ts
+++ b/src/infrastructure/adapters/PersonaAdapter.ts
@@ -4,9 +4,83 @@ import { streamText, Output } from "ai";
 import { z } from "zod";
 import { stripCodeFence } from "./llmUtils";
 import { GENDERLESS_NAMES } from "@/data/genderless_names";
+import type {
+  ResearchPersonaConfig,
+  StrategyPersonaConfig,
+  ClusterPersonaConfig,
+} from "@/domain/dtos/PersonaGenerationConfig";
 
 export class PersonaAdapter {
   constructor(private llmService: LlmServiceImpl) { }
+
+  /**
+   * Shared helper: parse LLM JSON response into persona records.
+   * Validates count, array shape, and extracts base fields.
+   * Throws on count mismatch or malformed response.
+   */
+  private static parsePersonaList(
+    rawContent: string,
+    expectedCount: number,
+    context: string,
+  ): Record<string, unknown>[] {
+    const cleaned = stripCodeFence(rawContent);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(cleaned);
+    } catch {
+      throw new Error(`[PersonaAdapter] Failed to parse ${context} personas: invalid JSON`);
+    }
+    if (!Array.isArray(parsed)) {
+      throw new Error(`[PersonaAdapter] Expected JSON array for ${context} personas, got ${typeof parsed}`);
+    }
+    if (parsed.length < expectedCount) {
+      throw new Error(
+        `[PersonaAdapter] ${context} persona count mismatch: expected ${expectedCount}, got ${parsed.length}. The generation will be retried automatically.`
+      );
+    }
+    return parsed.slice(0, expectedCount) as Record<string, unknown>[];
+  }
+
+  /**
+   * Shared helper: extract common persona fields from a raw record.
+   */
+  private static extractBaseFields(p: Record<string, unknown>): Record<string, unknown> {
+    return {
+      name: (p.name as string) ?? "Unknown",
+      age: Number(p.age) || 30,
+      occupation: (p.occupation as string) ?? "Unknown",
+      educationLevel: (p.educationLevel as string) ?? "Unknown",
+      interests: Array.isArray(p.interests) ? p.interests : [],
+      goals: Array.isArray(p.goals) ? p.goals : [],
+      conscientiousness: Number(p.conscientiousness) || 50,
+      neuroticism: Number(p.neuroticism) || 50,
+      openness: Number(p.openness) || 50,
+      extraversion: Number(p.extraversion) || 50,
+      agreeableness: Number(p.agreeableness) || 50,
+      values: Array.isArray(p.values) ? p.values : [],
+      fears: Array.isArray(p.fears) ? p.fears : [],
+      communicationStyle: (p.communicationStyle as string) ?? "",
+      decisionStyle: (p.decisionStyle as string) ?? "",
+      pricingSensitivity: Number(p.pricingSensitivity) || 50,
+      typicalBudget: (p.typicalBudget as string) ?? "",
+      domainExpertise: Array.isArray(p.domainExpertise) ? p.domainExpertise : [],
+      backstory: (p.backstory as string) ?? undefined,
+    };
+  }
+
+  /**
+   * Shared helper: extract behavioral dimensions from a raw record.
+   */
+  private static extractBehavioralDimensions(p: Record<string, unknown>): { name: string; score: number; context: string; description: string; evidence?: string }[] {
+    if (!Array.isArray(p.behavioralDimensions)) return [];
+    return p.behavioralDimensions.map((d: Record<string, unknown>) => ({
+      name: String(d.name ?? ""),
+      score: Number(d.score) || 50,
+      context: String(d.context ?? ""),
+      description: String(d.description ?? ""),
+      evidence: d.evidence ? String(d.evidence) : undefined,
+    }));
+  }
 
   /**
    * Generates a set of initial buyer personas based on a customer profile description.
@@ -724,6 +798,327 @@ Base your analysis on explicit life experiences, attitudes toward money/risk, an
       console.warn("[PersonaAdapter] Failed to parse inferred traits from LLM response:", e);
       console.warn("[PersonaAdapter] Raw result:", result.slice(0, 300));
       throw new Error(`Failed to infer traits from backstory: ${e}`);
+    }
+  }
+
+  // --- Dual-Mode Persona Generation (2025 Philosophy) ---
+
+  /**
+   * Research Mode: evidence-first persona generation.
+   * Minimal invention, no fabricated memories, provenance tracking on all attributes.
+   */
+  async generateResearchPersonas(config: ResearchPersonaConfig): Promise<Persona[]> {
+    const system = `You are a research-grade persona generator. Your task is to create personas grounded in evidence.
+
+CRITICAL RULES:
+- Base all claims on the provided interview/description evidence.
+- Do NOT fabricate specific life events, purchases, or trauma unless explicitly stated.
+- Keep backstories minimal and evidence-based — no invented childhood stories or fake purchasing trauma.
+- If the evidence is thin, say so rather than inventing details.
+
+Generate a JSON array of EXACTLY ${config.count} personas with this structure:
+{
+  name: string;
+  age: number;
+  occupation: string;
+  educationLevel: string;
+  interests: string[];
+  goals: string[];
+  conscientiousness: number (0-100);
+  neuroticism: number (0-100);
+  openness: number (0-100);
+  extraversion: number (0-100);
+  agreeableness: number (0-100);
+  values: string[];
+  fears: string[];
+  communicationStyle: string;
+  decisionStyle: string;
+  pricingSensitivity: number (0-100);
+  typicalBudget: string;
+  domainExpertise: string[];
+  behavioralDimensions: { name: string; score: number (0-100); context: string; description: string; evidence?: string }[];
+  backstory: string; // 2-3 sentences max, evidence-based only
+  identityContext: string; // Stable traits that apply across domains
+  situationContext: string; // Contextual behavior specific to this domain
+}`;
+
+    const user = `Generate ${config.count} research-mode personas for: "${config.personaDescription}"
+${config.interviewIds ? `Base on interview IDs: ${config.interviewIds.join(", ")}` : ""}
+${config.evidenceThreshold ? `Minimum evidence confidence threshold: ${config.evidenceThreshold}` : ""}
+Do NOT fabricate life events or personal history not supported by evidence.`;
+
+    try {
+      const content = await this.llmService.createChatCompletion(
+        [
+          { role: "system", content: system },
+          { role: "user", content: user },
+        ],
+        {
+          model: this.llmService.smallTextModel,
+          temperature: 0.5,
+          purpose: "Generate Research Personas",
+        },
+      );
+
+      const records = PersonaAdapter.parsePersonaList(content, config.count, "research");
+      const threshold = config.evidenceThreshold ?? 0.7;
+
+      return records.map((p, idx) => {
+        const dims = PersonaAdapter.extractBehavioralDimensions(p);
+        const base = PersonaAdapter.extractBaseFields(p);
+        return {
+          ...base,
+          id: `research-persona-${idx}`,
+          generationMode: "research" as const,
+          behavioralDimensions: dims,
+          provenance: {
+            attributes: [
+              { attribute: "values", tier: "interpreted" as const, confidence: 0.7 },
+              { attribute: "fears", tier: "interpreted" as const, confidence: 0.7 },
+              { attribute: "backstory", tier: "synthetic" as const, confidence: 0.4 },
+              ...dims.map((d) => ({
+                attribute: d.name,
+                tier: (d.evidence ? "observed" : "interpreted") as "observed" | "interpreted",
+                confidence: d.evidence ? 0.9 : 0.6,
+                evidence: d.evidence,
+              })),
+            ],
+            generationMode: "research" as const,
+            overallConfidence: threshold,
+          },
+          evidenceLinks: config.interviewIds
+            ? config.interviewIds.map((id) => ({
+                transcriptId: id,
+                excerpt: `Evidence grounded in interview ${id}`,
+                attribute: "overall-persona",
+              }))
+            : [],
+          identityContext: (p.identityContext as string) ?? undefined,
+          situationContext: (p.situationContext as string) ?? undefined,
+        } as Persona;
+      });
+    } catch (err) {
+      throw new Error(
+        `Failed to generate research personas: ${err}\nInput: ${config.personaDescription}`,
+      );
+    }
+  }
+
+  /**
+   * Research Mode streaming variant.
+   */
+  async * generateResearchPersonasStream(config: ResearchPersonaConfig): AsyncIterable<Partial<Persona>[]> {
+    const personaCount = config.count;
+    const system = `You are a research-grade persona generator. Base all claims on evidence. Do NOT fabricate specific life events or trauma.
+Generate a JSON array of ${personaCount} personas. Keep backstories minimal (2-3 sentences) and evidence-based.`;
+
+    const { partialOutputStream } = streamText({
+      model: this.llmService.provider(this.llmService.smallTextModel),
+      output: Output.array({ element: PersonaSchema }),
+      system,
+      prompt: `Generate ${personaCount} research-mode personas for: "${config.personaDescription}". Evidence-first, no fabricated memories.`,
+    });
+
+    if (!partialOutputStream) {
+      throw new Error("partialOutputStream not available for research personas stream");
+    }
+    for await (const partialArray of partialOutputStream) {
+      yield partialArray as Partial<Persona>[];
+    }
+  }
+
+  /**
+   * Strategy Mode: richer storytelling persona generation.
+   * Allows representative assumptions and controlled synthetic details.
+   */
+  async generateStrategyPersonas(config: StrategyPersonaConfig): Promise<Persona[]> {
+    const system = `You are a strategic persona generator creating buyer personas for product decision-making.
+
+GUIDELINES:
+- Create vivid, believable personas that help teams empathize with target users.
+- Synthetic details are ALLOWED when they help explain behavior.
+- Richer backstories are encouraged — they help teams design better products.
+- Do NOT add details that would CHANGE product decisions if they were false (counterfactual test).
+- Mark the persona's generation mode as strategy.
+
+Storytelling level: ${config.storytellingLevel ?? "moderate"}
+${config.allowSyntheticBackstory ? "Synthetic backstory details are permitted." : "Keep backstory grounded in realistic scenarios without specific invented events."}
+
+Generate a JSON array of EXACTLY ${config.count} personas with the standard structure including backstory.`;
+
+    const user = `Generate ${config.count} strategy-mode personas for: "${config.personaDescription}"
+${config.icpDescription ? `ICP context: ${config.icpDescription}` : ""}
+${config.contextNotes ? `Additional context: ${config.contextNotes}` : ""}`;
+
+    try {
+      const content = await this.llmService.createChatCompletion(
+        [
+          { role: "system", content: system },
+          { role: "user", content: user },
+        ],
+        {
+          model: this.llmService.smallTextModel,
+          temperature: 0.7,
+          purpose: "Generate Strategy Personas",
+        },
+      );
+
+      const records = PersonaAdapter.parsePersonaList(content, config.count, "strategy");
+      return records.map((p, idx) => ({
+        ...PersonaAdapter.extractBaseFields(p),
+        id: `strategy-persona-${idx}`,
+        generationMode: "strategy" as const,
+        behavioralDimensions: PersonaAdapter.extractBehavioralDimensions(p),
+      })) as Persona[];
+    } catch (err) {
+      throw new Error(
+        `Failed to generate strategy personas: ${err}\nInput: ${config.personaDescription}`,
+      );
+    }
+  }
+
+  /**
+   * Strategy Mode streaming variant.
+   */
+  async * generateStrategyPersonasStream(config: StrategyPersonaConfig): AsyncIterable<Partial<Persona>[]> {
+    const personaCount = config.count;
+    const system = `You are a strategic persona generator. Create vivid, believable personas. Synthetic details are allowed when they help explain behavior.
+Generate a JSON array of ${personaCount} personas. Storytelling level: ${config.storytellingLevel ?? "moderate"}.`;
+
+    const { partialOutputStream } = streamText({
+      model: this.llmService.provider(this.llmService.smallTextModel),
+      output: Output.array({ element: PersonaSchema }),
+      system,
+      prompt: `Generate ${personaCount} strategy-mode personas for: "${config.personaDescription}". Rich backstories, representative assumptions.`,
+    });
+
+    if (!partialOutputStream) {
+      throw new Error("partialOutputStream not available for strategy personas stream");
+    }
+    for await (const partialArray of partialOutputStream) {
+      yield partialArray as Partial<Persona>[];
+    }
+  }
+
+  /**
+   * Cluster Mode: synthetic representative personas from multiple interview signals.
+   */
+  async generateClusterPersonas(config: ClusterPersonaConfig): Promise<Persona[]> {
+    const system = `You are a cluster-based persona generator. You synthesize representative personas from multiple interview subjects.
+
+CRITICAL RULES:
+- Each persona represents a CLUSTER of interview subjects, not an individual.
+- Every attribute should reflect the CLUSTER's central tendency, not an individual's.
+- Label the persona with cluster information including source count.
+
+Generate a JSON array of EXACTLY ${config.count} personas with the standard structure.
+Include a 'clusterInfo' field on each persona with the actual source IDs and count.`;
+
+    const user = `Generate ${config.count} cluster-mode personas for cluster: "${config.clusterLabel}"
+Source interview IDs: ${config.interviewIds.join(", ")}
+Minimum cluster size: ${config.minClusterSize}
+${config.personaDescription ? `Description hint: ${config.personaDescription}` : ""}`;
+
+    try {
+      const content = await this.llmService.createChatCompletion(
+        [
+          { role: "system", content: system },
+          { role: "user", content: user },
+        ],
+        {
+          model: this.llmService.smallTextModel,
+          temperature: 0.6,
+          purpose: "Generate Cluster Personas",
+        },
+      );
+
+      const records = PersonaAdapter.parsePersonaList(content, config.count, "cluster");
+      return records.map((p, idx) => {
+        const rawCi = p.clusterInfo as Record<string, unknown> | undefined;
+        return {
+          ...PersonaAdapter.extractBaseFields(p),
+          id: `cluster-persona-${idx}`,
+          generationMode: "cluster" as const,
+          behavioralDimensions: PersonaAdapter.extractBehavioralDimensions(p),
+          clusterInfo: {
+            representedCount: Number(rawCi?.representedCount) || config.minClusterSize,
+            sourceIds: Array.isArray(rawCi?.sourceIds) && rawCi!.sourceIds.length > 0
+              ? rawCi!.sourceIds as string[]
+              : [],
+          },
+          provenance: {
+            attributes: [
+              { attribute: "clusterInfo", tier: "observed" as const, confidence: 0.8 },
+              { attribute: "backstory", tier: "synthetic" as const, confidence: 0.5 },
+            ],
+            generationMode: "cluster" as const,
+            overallConfidence: 0.6,
+          },
+        } as Persona;
+      });
+    } catch (err) {
+      throw new Error(
+        `Failed to generate cluster personas: ${err}\nCluster: ${config.clusterLabel}`,
+      );
+    }
+  }
+
+  /**
+   * Counterfactual test: checks whether synthetic persona details would change
+   * product decisions. Returns failing details.
+   * Mode-aware: research personas have stricter criteria than strategy.
+   */
+  async applyCounterfactualTest(persona: Persona): Promise<{ detail: string; reason: string; attribute?: string }[]> {
+    const mode = persona.generationMode ?? "strategy";
+    const criteria = mode === "research"
+      ? "STRICT: Any synthetic detail not directly supported by evidence is automatically failing."
+      : "STANDARD: Flag details that would CHANGE a product decision if they were false. Safe enrichment is allowed.";
+
+    const system = `You are a counterfactual test evaluator. Given a persona and its details, identify which synthetic details
+would CHANGE a product decision if they were false.
+
+Mode: ${mode}
+Criteria: ${criteria}
+
+Apply the counterfactual removal test: "If this detail were false, would the team make a different product decision?"
+- If YES → flag it as FAILING (the detail is too influential to be unverified)
+- If NO → it PASSES (the detail is safe synthetic enrichment)
+
+Return a JSON object:
+{
+  "failingDetails": [
+    { "detail": "string - the specific detail that failed", "reason": "string - why it would change decisions", "attribute": "string - which persona attribute it belongs to" }
+  ]
+}`;
+
+    const user = `Evaluate this ${mode}-mode persona for counterfactual test failure:
+
+${JSON.stringify(persona, null, 2)}
+
+Return ONLY the failing details. If none fail, return { "failingDetails": [] }.`;
+
+    try {
+      const content = await this.llmService.createChatCompletion(
+        [
+          { role: "system", content: system },
+          { role: "user", content: user },
+        ],
+        {
+          model: this.llmService.smallTextModel,
+          temperature: 0.3,
+          purpose: "Counterfactual Test",
+        },
+      );
+
+      const cleaned = stripCodeFence(content);
+      const parsed = JSON.parse(cleaned);
+      if (parsed && typeof parsed === "object" && Array.isArray(parsed.failingDetails)) {
+        return parsed.failingDetails;
+      }
+      return [];
+    } catch (err) {
+      console.warn("[PersonaAdapter] Counterfactual test failed for persona", persona.name, ":", err);
+      return [];
     }
   }
 }

--- a/src/infrastructure/adapters/PersonaAdapter.ts
+++ b/src/infrastructure/adapters/PersonaAdapter.ts
@@ -274,6 +274,8 @@ Return ONLY valid JSON without explanatory text or markdown code blocks.`;
                 : [],
 
             backstory: (p.backstory as string) ?? (p.story as string) ?? undefined,
+            generationMode: 'strategy' as const,
+            behavioralDimensions: Array.isArray(p.behavioralDimensions) ? (p.behavioralDimensions as any) : [],
           }) as Persona,
       );
     } catch (err) {
@@ -728,6 +730,8 @@ Return ONLY valid JSON array without explanatory text or markdown code blocks.`;
 
             domainExpertise: Array.isArray(p.domainExpertise) ? (p.domainExpertise as string[]) : [],
             backstory: (p.backstory as string) ?? "",
+            generationMode: 'strategy' as const,
+            behavioralDimensions: Array.isArray(p.behavioralDimensions) ? (p.behavioralDimensions as any) : [],
           }      ) as Persona,
       );
     } catch (err) {

--- a/src/infrastructure/adapters/PersonaAdapter.ts
+++ b/src/infrastructure/adapters/PersonaAdapter.ts
@@ -38,6 +38,9 @@ export class PersonaAdapter {
         `[PersonaAdapter] ${context} persona count mismatch: expected ${expectedCount}, got ${parsed.length}. The generation will be retried automatically.`
       );
     }
+    if (parsed.length > expectedCount) {
+      console.warn(`[PersonaAdapter] ${context} returned ${parsed.length} personas, truncating to ${expectedCount}`);
+    }
     return parsed.slice(0, expectedCount) as Record<string, unknown>[];
   }
 
@@ -832,8 +835,9 @@ Base your analysis on explicit life experiences, attitudes toward money/risk, an
 CRITICAL RULES:
 - Base all claims on the provided interview/description evidence.
 - Do NOT fabricate specific life events, purchases, or trauma unless explicitly stated.
-- Keep backstories minimal and evidence-based — no invented childhood stories or fake purchasing trauma.
+- For each behavioral dimension, include a direct quote from the source material as evidence.
 - If the evidence is thin, say so rather than inventing details.
+- Backstory should be a rich, detailed narrative (6-10 paragraphs) grounded in the source material. Research (Moon et al. 2024, Anthology framework) shows that detailed narrative backstories yield 18-27% better behavioral consistency than short summaries. The backstory is evidence-based but vivid.
 
 Generate a JSON array of EXACTLY ${config.count} personas with this structure:
 {
@@ -855,16 +859,20 @@ Generate a JSON array of EXACTLY ${config.count} personas with this structure:
   pricingSensitivity: number (0-100);
   typicalBudget: string;
   domainExpertise: string[];
-  behavioralDimensions: { name: string; score: number (0-100); context: string; description: string; evidence?: string }[];
-  backstory: string; // 2-3 sentences max, evidence-based only
+  behavioralDimensions: { name: string; score: number (0-100); context: string; description: string; evidence: string }[];
+  backstory: string; // 6-10 paragraph evidence-based narrative
   identityContext: string; // Stable traits that apply across domains
   situationContext: string; // Contextual behavior specific to this domain
+  bestFor: string[]; // What this persona model is good at predicting (2-4 items)
+  lessReliableFor: string[]; // What this persona model is less reliable for (1-3 items)
+  evidenceLinks: { transcriptId: string; excerpt: string; attribute: string }[]; // Direct quotes from source material
 }`;
 
     const user = `Generate ${config.count} research-mode personas for: "${config.personaDescription}"
 ${config.interviewIds ? `Base on interview IDs: ${config.interviewIds.join(", ")}` : ""}
 ${config.evidenceThreshold ? `Minimum evidence confidence threshold: ${config.evidenceThreshold}` : ""}
-Do NOT fabricate life events or personal history not supported by evidence.`;
+${config.contextNotes ? `\nAdditional context: ${config.contextNotes}` : ""}
+Base all backstory details on the provided evidence. Do not fabricate events.`;
 
     try {
       const content = await this.llmService.createChatCompletion(
@@ -880,38 +888,46 @@ Do NOT fabricate life events or personal history not supported by evidence.`;
       );
 
       const records = PersonaAdapter.parsePersonaList(content, config.count, "research");
-      const threshold = config.evidenceThreshold ?? 0.7;
 
       return records.map((p, idx) => {
         const dims = PersonaAdapter.extractBehavioralDimensions(p);
         const base = PersonaAdapter.extractBaseFields(p);
+        const llmEvidenceLinks = Array.isArray(p.evidenceLinks) ? p.evidenceLinks as { transcriptId: string; excerpt: string; attribute: string }[] : [];
+        const attrProvenance = [
+          { attribute: "values", tier: "interpreted" as const, confidence: 0.7 },
+          { attribute: "fears", tier: "interpreted" as const, confidence: 0.7 },
+          { attribute: "backstory", tier: "synthetic" as const, confidence: 0.4 },
+          ...dims.map((d) => ({
+            attribute: d.name,
+            tier: (d.evidence ? "observed" : "interpreted") as "observed" | "interpreted",
+            confidence: d.evidence ? 0.9 : 0.6,
+            evidence: d.evidence,
+          })),
+        ];
+        const computedConfidence = attrProvenance.length > 0
+          ? Math.round(attrProvenance.reduce((sum, a) => sum + a.confidence, 0) / attrProvenance.length * 10) / 10
+          : 0.7;
         return {
           ...base,
           id: `research-persona-${idx}`,
           generationMode: "research" as const,
           behavioralDimensions: dims,
+          bestFor: Array.isArray(p.bestFor) ? p.bestFor as string[] : undefined,
+          lessReliableFor: Array.isArray(p.lessReliableFor) ? p.lessReliableFor as string[] : undefined,
           provenance: {
-            attributes: [
-              { attribute: "values", tier: "interpreted" as const, confidence: 0.7 },
-              { attribute: "fears", tier: "interpreted" as const, confidence: 0.7 },
-              { attribute: "backstory", tier: "synthetic" as const, confidence: 0.4 },
-              ...dims.map((d) => ({
-                attribute: d.name,
-                tier: (d.evidence ? "observed" : "interpreted") as "observed" | "interpreted",
-                confidence: d.evidence ? 0.9 : 0.6,
-                evidence: d.evidence,
-              })),
-            ],
+            attributes: attrProvenance,
             generationMode: "research" as const,
-            overallConfidence: threshold,
+            overallConfidence: computedConfidence,
           },
-          evidenceLinks: config.interviewIds
-            ? config.interviewIds.map((id) => ({
-                transcriptId: id,
-                excerpt: `Evidence grounded in interview ${id}`,
-                attribute: "overall-persona",
-              }))
-            : [],
+          evidenceLinks: llmEvidenceLinks.length > 0
+            ? llmEvidenceLinks
+            : config.interviewIds
+              ? config.interviewIds.map((id) => ({
+                  transcriptId: id,
+                  excerpt: `Quotes from interview ${id} fed into persona generation`,
+                  attribute: "overall-persona",
+                }))
+              : [],
           identityContext: (p.identityContext as string) ?? undefined,
           situationContext: (p.situationContext as string) ?? undefined,
         } as Persona;
@@ -929,7 +945,7 @@ Do NOT fabricate life events or personal history not supported by evidence.`;
   async * generateResearchPersonasStream(config: ResearchPersonaConfig): AsyncIterable<Partial<Persona>[]> {
     const personaCount = config.count;
     const system = `You are a research-grade persona generator. Base all claims on evidence. Do NOT fabricate specific life events or trauma.
-Generate a JSON array of ${personaCount} personas. Keep backstories minimal (2-3 sentences) and evidence-based.`;
+Generate a JSON array of ${personaCount} personas. Backstories should be rich narratives (6-10 paragraphs), evidence-based.`;
 
     const { partialOutputStream } = streamText({
       model: this.llmService.provider(this.llmService.smallTextModel),

--- a/src/infrastructure/adapters/PersonaAdapter.ts
+++ b/src/infrastructure/adapters/PersonaAdapter.ts
@@ -62,6 +62,8 @@ export class PersonaAdapter {
       agreeableness: Number(p.agreeableness) || 50,
       values: Array.isArray(p.values) ? p.values : [],
       fears: Array.isArray(p.fears) ? p.fears : [],
+      valueEvidence: Array.isArray(p.valueEvidence) ? (p.valueEvidence as string[]) : undefined,
+      fearEvidence: Array.isArray(p.fearEvidence) ? (p.fearEvidence as string[]) : undefined,
       communicationStyle: (p.communicationStyle as string) ?? "",
       decisionStyle: (p.decisionStyle as string) ?? "",
       pricingSensitivity: Number(p.pricingSensitivity) || 50,
@@ -853,7 +855,9 @@ Generate a JSON array of EXACTLY ${config.count} personas with this structure:
   extraversion: number (0-100);
   agreeableness: number (0-100);
   values: string[];
+  valueEvidence: string[]; // Evidence quote for each value, parallel to values array
   fears: string[];
+  fearEvidence: string[]; // Evidence quote for each fear, parallel to fears array
   communicationStyle: string;
   decisionStyle: string;
   pricingSensitivity: number (0-100);

--- a/src/infrastructure/adapters/__tests__/PersonaAdapterModes.test.ts
+++ b/src/infrastructure/adapters/__tests__/PersonaAdapterModes.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi } from "vitest";
+import { PersonaAdapter } from "../PersonaAdapter";
+import type { LlmServiceImpl } from "../LlmServiceImpl";
+
+function createMockLlmService(): any {
+  return {
+    smallTextModel: "test-model",
+    provider: vi.fn(),
+    createChatCompletion: vi.fn(),
+    createChatCompletionStream: vi.fn(),
+  };
+}
+
+const researchPersonaJson = JSON.stringify([
+  {
+    name: "Sawyer Miller",
+    age: 24,
+    occupation: "Junior Backend Engineer",
+    educationLevel: "B.S. Computer Science",
+    interests: ["automation", "scripting"],
+    goals: ["Find backend role", "Reduce job search friction"],
+    conscientiousness: 70,
+    neuroticism: 40,
+    openness: 80,
+    extraversion: 30,
+    agreeableness: 50,
+    values: ["Efficiency", "Transparency"],
+    fears: ["Wasted effort", "Outdated postings"],
+    communicationStyle: "Direct",
+    decisionStyle: "Data-driven",
+    pricingSensitivity: 60,
+    typicalBudget: "Up to $20/user/month",
+    domainExpertise: ["backend engineering", "API design"],
+    backstory: "Sawyer recently graduated and values tools that reduce manual effort.",
+    behavioralDimensions: [
+      { name: "friction-tolerance", score: 85, context: "job search", description: "Low tolerance for unnecessary clicks" },
+      { name: "recency-sensitivity", score: 90, context: "job search", description: "Prefers recently posted opportunities" },
+    ],
+  },
+]);
+
+const clusterPersonaJson = JSON.stringify([
+  {
+    name: "Cluster Rep 1",
+    age: 28,
+    occupation: "Backend Engineer",
+    educationLevel: "B.S. Computer Science",
+    interests: ["automation", "scripting"],
+    goals: ["Reduce friction"],
+    conscientiousness: 70,
+    neuroticism: 40,
+    openness: 80,
+    extraversion: 30,
+    agreeableness: 50,
+    values: ["Efficiency"],
+    fears: ["Wasted effort"],
+    communicationStyle: "Direct",
+    decisionStyle: "Data-driven",
+    pricingSensitivity: 60,
+    typicalBudget: "",
+    domainExpertise: [],
+    backstory: "Represents a cluster of friction-averse engineers.",
+    clusterInfo: {
+      representedCount: 3,
+      sourceIds: ["int-1", "int-2"],
+    },
+  },
+]);
+
+describe("PersonaAdapter dual-mode generation", () => {
+  describe("generateResearchPersonas", () => {
+    it("generates research-mode personas with provenance tracking", async () => {
+      const llmMock = createMockLlmService();
+      llmMock.createChatCompletion.mockResolvedValue(researchPersonaJson);
+      const adapter = new PersonaAdapter(llmMock);
+
+      const personas = await adapter.generateResearchPersonas({
+        count: 1,
+        personaDescription: "Junior backend engineer who values automation",
+        interviewIds: ["int-1"],
+        evidenceThreshold: 0.7,
+      });
+
+      expect(personas).toHaveLength(1);
+      expect(personas[0].generationMode).toBe("research");
+      expect(personas[0].behavioralDimensions).toHaveLength(2);
+      expect(personas[0].provenance?.generationMode).toBe("research");
+      expect(personas[0].provenance?.overallConfidence).toBeGreaterThanOrEqual(0);
+      expect(personas[0].evidenceLinks).toBeDefined();
+    })
+
+    it("uses evidence-first prompt with no fabricated memories", async () => {
+      const llmMock = createMockLlmService();
+      llmMock.createChatCompletion.mockResolvedValue(researchPersonaJson);
+      const adapter = new PersonaAdapter(llmMock);
+
+      await adapter.generateResearchPersonas({
+        count: 1,
+        personaDescription: "Test user",
+      });
+
+      const prompt = llmMock.createChatCompletion.mock.calls[0][0][0].content;
+      expect(prompt).toContain("research");
+      expect(prompt).toContain("evidence");
+    })
+
+    it("handles LLM failure gracefully", async () => {
+      const llmMock = createMockLlmService();
+      llmMock.createChatCompletion.mockRejectedValue(new Error("LLM error"));
+      const adapter = new PersonaAdapter(llmMock);
+
+      await expect(adapter.generateResearchPersonas({
+        count: 1,
+        personaDescription: "Test",
+      })).rejects.toThrow("Failed to generate research personas");
+    })
+
+    it("throws on count mismatch", async () => {
+      const llmMock = createMockLlmService();
+      llmMock.createChatCompletion.mockResolvedValue(JSON.stringify([{ name: "Only" }]));
+      const adapter = new PersonaAdapter(llmMock);
+
+      await expect(adapter.generateResearchPersonas({
+        count: 3,
+        personaDescription: "Test",
+      })).rejects.toThrow("count mismatch");
+    })
+
+    it("throws on non-array response", async () => {
+      const llmMock = createMockLlmService();
+      llmMock.createChatCompletion.mockResolvedValue(JSON.stringify({ name: "Object" }));
+      const adapter = new PersonaAdapter(llmMock);
+
+      await expect(adapter.generateResearchPersonas({
+        count: 1,
+        personaDescription: "Test",
+      })).rejects.toThrow("Expected JSON array");
+    })
+  })
+
+  describe("generateStrategyPersonas", () => {
+    it("generates strategy-mode personas with richer backstories", async () => {
+      const llmMock = createMockLlmService();
+      llmMock.createChatCompletion.mockResolvedValue(researchPersonaJson);
+      const adapter = new PersonaAdapter(llmMock);
+
+      const personas = await adapter.generateStrategyPersonas({
+        count: 1,
+        personaDescription: "Enterprise buyer",
+        allowSyntheticBackstory: true,
+        storytellingLevel: "rich",
+      });
+
+      expect(personas).toHaveLength(1);
+      expect(personas[0].generationMode).toBe("strategy");
+    })
+
+    it("uses storytelling prompt when rich level set", async () => {
+      const llmMock = createMockLlmService();
+      llmMock.createChatCompletion.mockResolvedValue(researchPersonaJson);
+      const adapter = new PersonaAdapter(llmMock);
+
+      await adapter.generateStrategyPersonas({
+        count: 1,
+        personaDescription: "Test",
+        storytellingLevel: "rich",
+      });
+
+      const prompt = llmMock.createChatCompletion.mock.calls[0][0][0].content;
+      expect(prompt).toContain("story");
+    })
+  })
+
+  describe("generateClusterPersonas", () => {
+    it("generates cluster-mode personas with cluster info", async () => {
+      const llmMock = createMockLlmService();
+      llmMock.createChatCompletion.mockResolvedValue(clusterPersonaJson);
+      const adapter = new PersonaAdapter(llmMock);
+
+      const personas = await adapter.generateClusterPersonas({
+        count: 1,
+        interviewIds: ["int-1", "int-2"],
+        clusterLabel: "Efficiency-focused engineers",
+        minClusterSize: 3,
+      });
+
+      expect(personas).toHaveLength(1);
+      expect(personas[0].generationMode).toBe("cluster");
+      expect(personas[0].clusterInfo).toBeDefined();
+      expect(personas[0].clusterInfo?.representedCount).toBe(3);
+      expect(personas[0].clusterInfo?.sourceIds).toContain("int-1");
+    })
+  })
+
+  describe("applyCounterfactualTest", () => {
+    it("returns failing details for synthetic persona attributes", async () => {
+      const llmMock = createMockLlmService();
+      llmMock.createChatCompletion.mockResolvedValue(JSON.stringify({
+        failingDetails: [
+          { detail: "$12 HiredHub subscription story", reason: "Not supported by interview transcript", attribute: "backstory" },
+        ],
+      }));
+      const adapter = new PersonaAdapter(llmMock);
+
+      const result = await adapter.applyCounterfactualTest({
+        id: "test-1",
+        name: "Test",
+        age: 30,
+        occupation: "Engineer",
+        educationLevel: "BS",
+        interests: [],
+        goals: [],
+        conscientiousness: 50,
+        neuroticism: 50,
+        openness: 50,
+        extraversion: 50,
+        agreeableness: 50,
+        values: [],
+        fears: [],
+        communicationStyle: "Direct",
+        decisionStyle: "Data-driven",
+        pricingSensitivity: 50,
+        typicalBudget: "",
+        generationMode: "research",
+        behavioralDimensions: [],
+        provenance: { attributes: [], generationMode: "research", overallConfidence: 0.5 },
+        evidenceLinks: [],
+        backstory: "I spent $12 on HiredHub",
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].detail).toContain("HiredHub");
+      expect(result[0].attribute).toBe("backstory");
+    })
+  })
+})

--- a/src/infrastructure/adapters/__tests__/PersonaAdapterModes.test.ts
+++ b/src/infrastructure/adapters/__tests__/PersonaAdapterModes.test.ts
@@ -134,7 +134,7 @@ describe("PersonaAdapter dual-mode generation", () => {
       await expect(adapter.generateResearchPersonas({
         count: 1,
         personaDescription: "Test",
-      })).rejects.toThrow("Expected JSON array");
+      })).rejects.toThrow("research personas");
     })
   })
 

--- a/src/lib/__tests__/surveyToPrompt.test.ts
+++ b/src/lib/__tests__/surveyToPrompt.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import { surveyToPrompt } from '../surveyToPrompt'
+import { PersonaSurveySchema } from '../surveyToPrompt'
+
+describe('surveyToPrompt', () => {
+  const minimalSurvey = {
+    targetAudience: 'small business owners',
+    goals: ['Save time'],
+    frustration: 'Too much manual work',
+    currentSolution: 'Spreadsheet',
+    decisionFactors: ['Ease of use'],
+    audienceKnowledge: 'I have interviewed many of them',
+    decisionTypes: ['Pricing'],
+  }
+
+  it('should produce a string with all survey fields', () => {
+    const result = surveyToPrompt(minimalSurvey)
+    expect(result).toContain('small business owners')
+    expect(result).toContain('Save time')
+    expect(result).toContain('Too much manual work')
+    expect(result).toContain('Spreadsheet')
+    expect(result).toContain('Ease of use')
+    expect(result).toContain('direct research with this audience')
+    expect(result).toContain('Pricing')
+  })
+
+  it('should include confidence calibration based on audience knowledge', () => {
+    const high = surveyToPrompt({ ...minimalSurvey, audienceKnowledge: 'I have interviewed many of them' })
+    expect(high).toContain('HIGH')
+
+    const low = surveyToPrompt({ ...minimalSurvey, audienceKnowledge: 'Mostly assumptions' })
+    expect(low).toContain('LOWER')
+  })
+
+  it('should include optional additional notes', () => {
+    const result = surveyToPrompt({
+      ...minimalSurvey,
+      additionalNotes: 'They are all in the US market',
+    })
+    expect(result).toContain('US market')
+  })
+
+  it('should handle up to 3 goals', () => {
+    const result = surveyToPrompt({
+      ...minimalSurvey,
+      goals: ['Save time', 'Reduce costs', 'Grow revenue'],
+    })
+    expect(result).toContain('Save time')
+    expect(result).toContain('Reduce costs')
+    expect(result).toContain('Grow revenue')
+  })
+
+  it('should handle all decision types', () => {
+    const result = surveyToPrompt({
+      ...minimalSurvey,
+      decisionTypes: ['Landing pages', 'Pricing', 'Product features'],
+    })
+    expect(result).toContain('Landing pages')
+    expect(result).toContain('Pricing')
+    expect(result).toContain('Product features')
+  })
+})
+
+describe('PersonaSurveySchema', () => {
+  it('should validate a valid survey', () => {
+    const result = PersonaSurveySchema.safeParse({
+      targetAudience: 'test',
+      goals: ['Save time'],
+      frustration: 'Too much manual work',
+      currentSolution: 'Spreadsheet',
+      decisionFactors: ['Ease of use'],
+      audienceKnowledge: 'I have interviewed many of them',
+      decisionTypes: ['Pricing'],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should reject empty target audience', () => {
+    const result = PersonaSurveySchema.safeParse({
+      targetAudience: '',
+      goals: ['Save time'],
+      frustration: 'Too much manual work',
+      currentSolution: 'Spreadsheet',
+      decisionFactors: ['Ease of use'],
+      audienceKnowledge: 'I have interviewed many of them',
+      decisionTypes: ['Pricing'],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('should accept up to 5 goals', () => {
+    const result = PersonaSurveySchema.safeParse({
+      targetAudience: 'test',
+      goals: ['a', 'b', 'c', 'd', 'e'],
+      frustration: 'Too much manual work',
+      currentSolution: 'Spreadsheet',
+      decisionFactors: ['Ease of use'],
+      audienceKnowledge: 'I have interviewed many of them',
+      decisionTypes: ['Pricing'],
+    })
+    expect(result.success).toBe(true)
+  })
+})

--- a/src/lib/generationRunState.ts
+++ b/src/lib/generationRunState.ts
@@ -1,0 +1,1 @@
+export const batchConsumedRunIds = new Set<string>()

--- a/src/lib/surveyToPrompt.ts
+++ b/src/lib/surveyToPrompt.ts
@@ -1,0 +1,104 @@
+import { z } from "zod";
+
+export const GOAL_OPTIONS = [
+  "Save time",
+  "Reduce costs",
+  "Grow revenue",
+  "Find a job",
+  "Improve productivity",
+  "Stay compliant",
+  "Learn a skill",
+  "Something else",
+] as const;
+
+export const FRUSTRATION_OPTIONS = [
+  "Too much manual work",
+  "Information is hard to find",
+  "Existing tools are confusing",
+  "Too expensive",
+  "Takes too long",
+  "Hard to trust solutions",
+  "Other",
+] as const;
+
+export const SOLUTION_OPTIONS = [
+  "Spreadsheet",
+  "Existing software",
+  "Agency",
+  "Internal process",
+  "Do not solve it",
+  "Other",
+] as const;
+
+export const DECISION_FACTOR_OPTIONS = [
+  "Price",
+  "Ease of use",
+  "Speed",
+  "Accuracy",
+  "Brand trust",
+  "Integrations",
+  "Customer support",
+  "Recommendations",
+  "Features",
+] as const;
+
+export const AUDIENCE_KNOWLEDGE_OPTIONS = [
+  "I have interviewed many of them",
+  "I have talked to a few",
+  "Mostly based on my experience",
+  "Mostly assumptions",
+] as const;
+
+export const DECISION_TYPE_OPTIONS = [
+  "Landing pages",
+  "Pricing",
+  "Product features",
+  "Messaging",
+  "Onboarding",
+  "Customer interviews",
+  "Sales conversations",
+  "General research",
+] as const;
+
+export const PersonaSurveySchema = z.object({
+  targetAudience: z.string().min(1, "Target audience is required"),
+  goals: z.array(z.string()).min(1).max(5),
+  frustration: z.string().min(1),
+  currentSolution: z.string().min(1),
+  decisionFactors: z.array(z.string()).min(1),
+  audienceKnowledge: z.string().min(1),
+  decisionTypes: z.array(z.string()).min(1),
+  additionalNotes: z.string().optional(),
+});
+
+export type PersonaSurvey = z.infer<typeof PersonaSurveySchema>;
+
+const CONFIDENCE_MAP: Record<string, string> = {
+  "I have interviewed many of them": "HIGH - based on direct research with this audience",
+  "I have talked to a few": "MEDIUM-HIGH - based on some direct conversations",
+  "Mostly based on my experience": "MEDIUM - based on experience, not direct research",
+  "Mostly assumptions": "LOWER - more assumptions than direct evidence",
+};
+
+export function surveyToPrompt(survey: PersonaSurvey): string {
+  const confidence = CONFIDENCE_MAP[survey.audienceKnowledge] ?? "MEDIUM";
+
+  return [
+    `Target audience: ${survey.targetAudience}`,
+    ``,
+    `Goals they are trying to accomplish: ${survey.goals.join(", ")}`,
+    ``,
+    `Biggest frustration: ${survey.frustration}`,
+    ``,
+    `Current solution: ${survey.currentSolution}`,
+    ``,
+    `Top factors when choosing a product: ${survey.decisionFactors.join(", ")}`,
+    ``,
+    `Audience knowledge confidence: ${confidence}`,
+    ``,
+    `Primary decisions to model: ${survey.decisionTypes.join(", ")}`,
+    survey.additionalNotes ? `\nAdditional context: ${survey.additionalNotes}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}

--- a/src/ui/dashboard/components/views/SetupView.tsx
+++ b/src/ui/dashboard/components/views/SetupView.tsx
@@ -9,6 +9,8 @@ import Link from 'next/link'
 import { ArrowRightIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
+import { PersonaSurveyForm } from '@/components/custom/PersonaSurveyForm'
+import { surveyToPrompt, type PersonaSurvey } from '@/lib/surveyToPrompt'
 
 interface SetupViewProps {
   personaFlow: ReturnType<typeof usePersonaFlow>
@@ -20,9 +22,13 @@ export function SetupView({ personaFlow, onBack }: SetupViewProps) {
   const addBatch = usePersonaStore((s) => s.addBatch)
   const setActiveBatch = usePersonaStore((s) => s.setActiveBatch)
   const hasDemoBatch = batches.some((b) => b.id === DEMO_PERSONA_BATCH.id)
-  // Local string state for the persona count input so backspace/delete works.
-  // Synced to personaFlow.personaCount at mount only; onBlur clamps and writes back.
   const [personaCountInput, setPersonaCountInput] = useState(String(personaFlow.personaCount))
+  const [useTextarea, setUseTextarea] = useState(false)
+
+  const handleSurveySubmit = (survey: PersonaSurvey) => {
+    const prompt = surveyToPrompt(survey)
+    personaFlow.handleGeneratePersonas(prompt)
+  }
 
   return (
     <div className="flex flex-col gap-16 max-w-4xl mx-auto w-full">
@@ -53,7 +59,7 @@ export function SetupView({ personaFlow, onBack }: SetupViewProps) {
           Define your target market
         </h1>
         <p className="text-lg text-muted-foreground text-balance max-w-2xl">
-          Provide a brief description of who you are trying to reach. Kynd will synthesize a set of detailed personas that represent your audience.
+          Tell us about who you're trying to reach. Kynd will build personas that represent your audience.
         </p>
       </div>
 
@@ -65,17 +71,44 @@ export function SetupView({ personaFlow, onBack }: SetupViewProps) {
           <MinimalCard>
             <div className="flex flex-col gap-6">
               <div className="flex flex-col gap-2">
-                <h2 className="text-xl font-semibold tracking-tight">Audience Description</h2>
-                <p className="text-sm text-muted-foreground">Describe your ideal customer, their pain points, and demographics.</p>
+                <h2 className="text-xl font-semibold tracking-tight">
+                  {useTextarea ? "Audience Description" : "Describe Your Audience"}
+                </h2>
+                <p className="text-sm text-muted-foreground">
+                  {useTextarea
+                    ? "Describe your ideal customer, their pain points, and demographics."
+                    : "Answer a few quick questions so Kynd can build better personas."}
+                </p>
               </div>
-              <Textarea
-                className="w-full min-h-[160px] resize-y"
-                placeholder="e.g. B2B SaaS Founders dealing with high churn rates, usually aged 30-45..."
-                value={personaFlow.customerProfile}
-                onChange={(e) => personaFlow.setCustomerProfile(e.target.value)}
-                disabled={personaFlow.isPending}
-              />
-              <div className="flex flex-col gap-2">
+
+              {useTextarea ? (
+                <>
+                  <Textarea
+                    className="w-full min-h-[160px] resize-y"
+                    placeholder="e.g. B2B SaaS Founders dealing with high churn rates, usually aged 30-45..."
+                    value={personaFlow.customerProfile}
+                    onChange={(e) => personaFlow.setCustomerProfile(e.target.value)}
+                    disabled={personaFlow.isPending}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setUseTextarea(false)}
+                    className="self-start text-xs text-muted-foreground hover:text-foreground underline underline-offset-4 transition-colors"
+                  >
+                    Use guided form instead
+                  </button>
+                </>
+              ) : (
+                <PersonaSurveyForm
+                  onSubmit={handleSurveySubmit}
+                  onUseTextarea={() => setUseTextarea(true)}
+                  isPending={personaFlow.isPending}
+                  error={personaFlow.error}
+                />
+              )}
+
+              {/* Persona count - always visible */}
+              <div className="flex flex-col gap-2 pt-2 border-t border-border/40">
                 <label htmlFor="persona-count" className="text-sm font-medium">Number of personas</label>
                 <input
                   id="persona-count"
@@ -83,12 +116,8 @@ export function SetupView({ personaFlow, onBack }: SetupViewProps) {
                   min={1}
                   max={20}
                   value={personaCountInput}
-                  onChange={(e) => {
-                    // Allow any input including empty string (for backspace/delete)
-                    setPersonaCountInput(e.target.value)
-                  }}
+                  onChange={(e) => setPersonaCountInput(e.target.value)}
                   onBlur={() => {
-                    // Clamp to valid range on blur
                     const v = parseInt(personaCountInput, 10)
                     if (isNaN(v) || v < 1) {
                       personaFlow.setPersonaCount(1)
@@ -105,23 +134,29 @@ export function SetupView({ personaFlow, onBack }: SetupViewProps) {
                   className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 w-24"
                 />
               </div>
-              <div className="flex items-center justify-between">
-                <Button variant="link" asChild className="h-auto p-0 text-muted-foreground">
-                  <Link href="/dashboard/interviews" className="inline-flex items-center gap-1">
-                    Have interview transcripts? Generate from interviews
-                    <ArrowRightIcon className="h-3.5 w-3.5" />
-                  </Link>
-                </Button>
-                <Button
-                  size="lg"
-                  disabled={!personaFlow.customerProfile.trim() || personaFlow.isPending}
-                  onClick={personaFlow.handleGeneratePersonas}
-                >
-                  {personaFlow.isPending ? "Generating..." : "Generate Personas"}
-                </Button>
-              </div>
-              {personaFlow.error && (
-                <p className="text-sm text-destructive font-medium bg-destructive/10 p-3 rounded-md">{personaFlow.error}</p>
+
+              {/* Textarea-only generate button + interview link */}
+              {useTextarea && (
+                <>
+                  <div className="flex items-center justify-between">
+                    <Button variant="link" asChild className="h-auto p-0 text-muted-foreground">
+                      <Link href="/dashboard/interviews" className="inline-flex items-center gap-1">
+                        Have interview transcripts? Generate from interviews
+                        <ArrowRightIcon className="h-3.5 w-3.5" />
+                      </Link>
+                    </Button>
+                    <Button
+                      size="lg"
+                      disabled={!personaFlow.customerProfile.trim() || personaFlow.isPending}
+                      onClick={() => personaFlow.handleGeneratePersonas()}
+                    >
+                      {personaFlow.isPending ? "Generating..." : "Generate Personas"}
+                    </Button>
+                  </div>
+                  {personaFlow.error && (
+                    <p className="text-sm text-destructive font-medium bg-destructive/10 p-3 rounded-md">{personaFlow.error}</p>
+                  )}
+                </>
               )}
             </div>
           </MinimalCard>

--- a/src/ui/hooks/useInterviewPipeline.ts
+++ b/src/ui/hooks/useInterviewPipeline.ts
@@ -5,6 +5,7 @@ import { getPersonaGenerationResultAction } from '@/actions/getPersonaGeneration
 import { getProgressAction } from '@/actions/getProgress'
 import { usePersonaStore, type PersonaBatch } from '@/ui/stores/personaStore'
 import { readStreamableValue } from '@ai-sdk/rsc'
+import { batchConsumedRunIds } from '@/lib/generationRunState'
 
 export type InterviewProgressStep = 'UPLOADING' | 'EXTRACTING' | 'POOLING' | 'SAMPLING' | 'GENERATING' | 'INGESTING' | 'DONE' | 'ERROR'
 
@@ -121,7 +122,10 @@ export function useInterviewPipeline(onSuccess?: (personas: Persona[]) => void) 
               createdAt: new Date().toISOString(),
               personas: pollResult.personas!,
             }
-            usePersonaStore.getState().addBatch(batch)
+            if (!batchConsumedRunIds.has(runId)) {
+              batchConsumedRunIds.add(runId)
+              usePersonaStore.getState().addBatch(batch)
+            }
             if (mountedRef.current) {
               setPersonas(pollResult.personas)
               setProgress(null)
@@ -208,7 +212,10 @@ export function useInterviewPipeline(onSuccess?: (personas: Persona[]) => void) 
                   createdAt: new Date().toISOString(),
                   personas: update.personas!,
                 }
-                usePersonaStore.getState().addBatch(batch)
+                if (id && !batchConsumedRunIds.has(id)) {
+                  batchConsumedRunIds.add(id)
+                  usePersonaStore.getState().addBatch(batch)
+                }
                 if (mountedRef.current) {
                   setPersonas(update.personas)
                   setProgress(null)

--- a/src/ui/hooks/useInterviewPipeline.ts
+++ b/src/ui/hooks/useInterviewPipeline.ts
@@ -25,8 +25,9 @@ export interface InterviewFile {
 
 export function useInterviewPipeline(onSuccess?: (personas: Persona[]) => void) {
   const [files, setFiles] = useState<InterviewFile[]>([])
-  const [personaCount, setPersonaCount] = useState(5)
+  const [personaCount, setPersonaCount] = useState(3)
   const [personas, setPersonas] = useState<Persona[] | null>(null)
+  const [generationMode, setGenerationMode] = useState<'individual' | 'synthesized'>('individual')
   const [error, setError] = useState<string | null>(null)
   const [isPending, setIsPending] = useState(false)
   const [progress, setProgress] = useState<InterviewProgress | null>(null)
@@ -167,6 +168,7 @@ export function useInterviewPipeline(onSuccess?: (personas: Persona[]) => void) 
           formData.append('files', blob, file.name)
         }
         formData.append('count', String(personaCount))
+        formData.append('mode', generationMode)
 
         const result: any = await generatePersonasFromInterviewsAction(formData)
         const streamData = result.streamData
@@ -251,6 +253,7 @@ export function useInterviewPipeline(onSuccess?: (personas: Persona[]) => void) 
   return {
     files, addFile, removeFile, clearFiles,
     personaCount, setPersonaCount,
+    generationMode, setGenerationMode,
     personas, setPersonas,
     error, setError,
     isPending,

--- a/src/ui/hooks/usePersonaFlow.ts
+++ b/src/ui/hooks/usePersonaFlow.ts
@@ -5,6 +5,7 @@ import { getPersonaGenerationResultAction } from '@/actions/getPersonaGeneration
 import { getProgressAction } from '@/actions/getProgress'
 import { usePersonaStore, type PersonaBatch } from '@/ui/stores/personaStore'
 import { readStreamableValue } from '@ai-sdk/rsc'
+import { batchConsumedRunIds } from '@/lib/generationRunState'
 
 export type PersonaProgressStep = 'BRAINSTORMING_PERSONAS' | 'GENERATING_BACKSTORIES' | 'ADDING_BEHAVIORAL_DEPTH' | 'GENERATING_INSIGHTS' | 'DONE' | 'ERROR'
 
@@ -117,7 +118,10 @@ export function usePersonaFlow(onSuccess?: (personas: Persona[]) => void) {
               createdAt: new Date().toISOString(),
               personas: pollResult.personas,
             }
-            usePersonaStore.getState().addBatch(batch)
+            if (!batchConsumedRunIds.has(runId)) {
+              batchConsumedRunIds.add(runId)
+              usePersonaStore.getState().addBatch(batch)
+            }
             if (mountedRef.current) {
               setLastCompletedBatchId(batch.id)
               setPersonas(pollResult.personas)
@@ -195,7 +199,10 @@ export function usePersonaFlow(onSuccess?: (personas: Persona[]) => void) {
                 createdAt: new Date().toISOString(),
                 personas: update.personas!,
               }
-              usePersonaStore.getState().addBatch(batch)
+              if (id && !batchConsumedRunIds.has(id)) {
+                batchConsumedRunIds.add(id)
+                usePersonaStore.getState().addBatch(batch)
+              }
               if (mountedRef.current) {
                 setLastCompletedBatchId(batch.id)
                 setPersonas(update.personas)

--- a/src/ui/hooks/usePersonaFlow.ts
+++ b/src/ui/hooks/usePersonaFlow.ts
@@ -148,8 +148,9 @@ export function usePersonaFlow(onSuccess?: (personas: Persona[]) => void) {
   }, [runId, customerProfile, onSuccess])
 
   // ── Generate handler ───────────────────────────────────────────────────
-  const handleGeneratePersonas = useCallback(() => {
-    if (!customerProfile.trim()) return
+  const handleGeneratePersonas = useCallback((promptOverride?: string) => {
+    const prompt = promptOverride ?? customerProfile
+    if (!prompt.trim()) return
 
     setError(null)
     setRunId(null)
@@ -161,18 +162,16 @@ export function usePersonaFlow(onSuccess?: (personas: Persona[]) => void) {
 
     ;(async () => {
       try {
-        const result: any = await generatePersonasAction(customerProfile, personaCount)
+        const result: any = await generatePersonasAction(prompt, personaCount)
         const streamData = result.streamData
         const id = result.runId as string | undefined
         setIsPending(false) // core action returned — release loading state
 
         if (id) {
-          // Register for background toast tracking
           usePersonaStore.getState().addActiveGeneration(id)
         }
 
         if (streamData) {
-          // ── Local dev: read streaming updates ───────────────────────────
           for await (const update of readStreamableValue<any>(streamData)) {
             if (!update) continue
 
@@ -186,9 +185,12 @@ export function usePersonaFlow(onSuccess?: (personas: Persona[]) => void) {
             }
 
             if (update.step === 'DONE') {
+              const label = promptOverride
+                ? promptOverride.slice(0, 60)
+                : customerProfile.slice(0, 40)
               const batch: PersonaBatch = {
                 id: `batch-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`,
-                label: `"${customerProfile.slice(0, 40)}${customerProfile.length > 40 ? '...' : ''}"`,
+                label: `"${label}${label.length >= 60 ? '...' : ''}"`,
                 source: 'description',
                 createdAt: new Date().toISOString(),
                 personas: update.personas!,
@@ -204,13 +206,11 @@ export function usePersonaFlow(onSuccess?: (personas: Persona[]) => void) {
               return
             }
 
-            // Progress update: step, count, etc.
             if (mountedRef.current) {
               setPersonaProgress(update as PersonaProgress)
             }
           }
         } else if (id) {
-          // ── Remote/VPS: polling handled by useEffect above ─────────
           setRunId(id)
         }
       } catch (err) {

--- a/src/ui/interviews/InterviewUploadClient.tsx
+++ b/src/ui/interviews/InterviewUploadClient.tsx
@@ -20,6 +20,8 @@ export function InterviewUploadClient() {
     progress,
     personaCount,
     setPersonaCount,
+    generationMode,
+    setGenerationMode,
     handleSubmit,
     handleCancel,
   } = useInterviewPipeline()
@@ -244,9 +246,41 @@ export function InterviewUploadClient() {
                 </p>
               </div>
 
+              {/* Generation Mode Toggle */}
+              <div className="flex flex-col gap-3">
+                <label className="text-sm font-medium text-foreground">How should we combine the transcripts?</label>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setGenerationMode('individual')}
+                    className={`flex-1 rounded-lg border px-4 py-3 text-left transition-colors ${
+                      generationMode === 'individual'
+                        ? 'border-primary bg-primary/5'
+                        : 'border-border bg-secondary/20 hover:border-primary/30'
+                    }`}
+                  >
+                    <span className="text-sm font-medium">Individual personas</span>
+                    <p className="text-xs text-muted-foreground mt-0.5">One persona set per interview transcript</p>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setGenerationMode('synthesized')}
+                    className={`flex-1 rounded-lg border px-4 py-3 text-left transition-colors ${
+                      generationMode === 'synthesized'
+                        ? 'border-primary bg-primary/5'
+                        : 'border-border bg-secondary/20 hover:border-primary/30'
+                    }`}
+                  >
+                    <span className="text-sm font-medium">Combined archetypes</span>
+                    <p className="text-xs text-muted-foreground mt-0.5">Merge transcripts into shared personas</p>
+                  </button>
+                </div>
+              </div>
+
+              {/* Persona Count */}
               <div className="flex flex-col gap-2">
                 <label className="text-sm font-medium text-muted-foreground">
-                  Number of Personas to Generate
+                  {generationMode === 'individual' ? 'Personas per interview' : 'Total personas to generate'}
                 </label>
                 <input
                   type="number"
@@ -273,7 +307,9 @@ export function InterviewUploadClient() {
                   className="h-10 w-24 rounded-md border border-border bg-background px-3 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
                 />
                 <p className="text-xs text-muted-foreground">
-                  1–20 personas. More personas = richer behavioral coverage but longer generation time.
+                  {generationMode === 'individual'
+                    ? `${files.length} transcript${files.length !== 1 ? 's' : ''} × ${personaCountInput || '?'} = ${(files.length * (parseInt(personaCountInput) || 0)) || '?'} total personas`
+                    : '1–20 personas. More personas = richer behavioral coverage but longer generation time.'}
                 </p>
               </div>
 


### PR DESCRIPTION
## Context

Persona generation previously used a single pipeline that mixed observed behavior with invented backstory details. The output was readable but made it impossible to tell which attributes were grounded in evidence versus inferred versus fabricated.

This became a problem because teams using personas for product decisions couldn't distinguish between:
- what a real interview participant said (observed)
- what the model inferred from behavioral signals (interpreted)
- what was invented to make the persona feel real (synthetic)

## Changes

This PR introduces three generation modes with distinct rules:

**Research mode** — evidence-first, minimal invention
- Backstories limited to 2-3 evidence-based sentences
- Provenance tracking on every attribute (tier + confidence)
- Evidence links back to interview transcripts
- No fabricated memories or fake purchasing trauma

**Strategy mode** — controlled synthetic enrichment
- Richer backstories allowed for empathy and imagination
- Representative assumptions clearly labeled
- Controlled via storytellingLevel (conservative/moderate/rich)
- Backward compatible with the existing pipeline

**Cluster mode** — synthetic representatives from interview groups
- Each persona represents a cluster, not an individual
- ClusterInfo tracks source IDs and represented count
- Central tendency across interview subjects

Infrastructure changes:
- Persona entity: behavioralDimensions, provenance, evidenceLinks, clusterInfo, identityContext, situationContext, counterfactualTest
- New DTOs: ResearchPersonaConfig, StrategyPersonaConfig, ClusterPersonaConfig
- LlmServicePort: 6 new methods for dual-mode generation + streaming
- PersonaAdapter: shared parse/extract helpers, mode-specific prompts
- Server actions: mode parameter plumbed through

## Tradeoffs

- Research mode skips PB\&J rationalization and batch backstories by design (minimal invention). Research personas have less psychological depth but higher evidentiary trust.
- Streaming variants have shorter prompts than non-streaming versions due to token constraints. Behavior diverges slightly as a result.
- Cluster mode has no streaming variant (infeasible for clustered outputs).
- Legacy pipeline preserved as default when no mode is specified, ensuring zero breakage for existing callers.