### PR TITLE
feat(persona): move cancel button to top while editing

### DIFF
--- a/src/components/custom/PersonaDetailSheet.tsx
+++ b/src/components/custom/PersonaDetailSheet.tsx
@@ -310,17 +310,17 @@ export function PersonaDetailSheet({
                             )}
                             {onEdit && (
                                 <button
-                                    onClick={isEditing ? undefined : handleStartEdit}
+                                    onClick={isEditing ? handleCancelEdit : handleStartEdit}
                                     className={cn(
                                         "inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-colors",
                                         isEditing
                                             ? "bg-primary/10 text-primary"
                                             : "text-muted-foreground hover:text-foreground"
                                     )}
-                                    aria-label={isEditing ? "Editing persona" : "Edit persona"}
+                                    aria-label={isEditing ? "Cancel editing" : "Edit persona"}
                                 >
-                                    <PenIcon className="w-3.5 h-3.5" />
-                                    {isEditing ? "Editing" : "Edit"}
+                                    {isEditing ? <XIcon className="w-3.5 h-3.5" /> : <PenIcon className="w-3.5 h-3.5" />}
+                                    {isEditing ? "Cancel" : "Edit"}
                                 </button>
                             )}
                             {persona.generationMode === 'strategy' && (
@@ -794,15 +794,8 @@ export function PersonaDetailSheet({
                                     </div>
                                 </div>
 
-                                {/* Save / Cancel */}
-                                <div className="flex gap-3 pt-2 pb-4">
-                                    <button
-                                        type="button"
-                                        onClick={handleCancelEdit}
-                                        className="flex-1 inline-flex h-10 items-center justify-center rounded-md border border-border/60 bg-card px-4 text-xs font-medium text-foreground transition-colors hover:bg-muted/30"
-                                    >
-                                        Cancel
-                                    </button>
+                                {/* Save */}
+                                <div className="flex pt-2 pb-4">
                                     <button
                                         type="button"
                                         onClick={handleSaveEdit}


### PR DESCRIPTION
## Summary

When editing a persona in the detail sheet, the **Cancel** button previously lived at the bottom of the edit form, forcing the user to scroll all the way down to back out of edits.

This moves Cancel to the top: while editing, the header **Edit** toggle becomes a **Cancel** button (with an ✕ icon), so it's always visible without scrolling. **Save Changes** stays at the bottom where the form ends.

## Changes

- `src/components/custom/PersonaDetailSheet.tsx`
  - Header: Edit button now toggles into a Cancel button when `isEditing` (icon swaps Pen → ✕, label swaps "Edit" → "Cancel", aria-label becomes "Cancel editing")
  - Removed the Cancel button from the bottom Save/Cancel row; Save is now a single full-width action

## Testing

- `npx vitest run src/components/custom/__tests__/PersonaDetailSheet.test.tsx` — 11/11 pass (includes "does not call onEdit on Cancel" and "shows Save and Cancel buttons in edit mode")
- `npx tsc --noEmit` — clean