### PR TITLE
feat(chat): chat with personas after a simulation

### DIFF
--- a/docs/external/persona-chat-after-simulation.md
+++ b/docs/external/persona-chat-after-simulation.md
@@ -1,0 +1,47 @@
+# Persona chat after simulation — where the stack lives
+
+Durable map for anyone extending the "chat with a persona after a simulation"
+feature. Written 2026-08-12 (feat/chat-after-simulation).
+
+## The chat stack (existing, was silently ungrounded)
+
+The chat feature was previously wired only into the pre-simulation views
+(`ResultsView`, `AudienceView`, `PersonaDetailSheet`) and hardcoded
+`analysis: null` — so personas could be interviewed before testing but never
+about what they actually saw. The full stack:
+
+- UI: `src/ui/dashboard/components/chat/PersonaChat.tsx` (modal),
+  `PersonaChatInline.tsx` (tab), `PanelChat.tsx` (cohort modal, new).
+- Action: `src/actions/chatWithPersona.ts`, `src/actions/chatWithPanel.ts`
+  (both dual-mode: local via use cases, remote via VPS API routes).
+- Use cases: `ChatWithPersonaUseCase`, `ChatWithPanelUseCase`.
+- Domain port: `LlmServicePort.chatWithPersonaStream`, `chatWithPanelStream`.
+- Adapter: `ChatAdapter` (ID-RAG backstory grounding) → `ChatPromptCompiler`
+  → `LlmServiceImpl.createChatCompletionStream` (OpenRouter).
+
+## Grounding types — the deprecated mismatch
+
+- `PricingAnalysis` (legacy, @deprecated) vs `PersonaResponse` (modern,
+  artifact-agnostic). Simulations produce `PersonaResponse[]`.
+- The chat context type is `ChatAnalysisContext = PricingAnalysis | PersonaResponse | null`
+  (defined in `LlmServicePort`). `ChatPromptCompiler.buildAnalysisContext`
+  renders "what you saw in the simulation" from a `PersonaResponse`
+  (overview, journey, findings, frictions, open questions, research answer).
+- `PersonaResponse.personaId` links back to the full `Persona`; the report
+  page resolves via `src/ui/dashboard/utils/resolveChatPersona.ts` (store
+  match by id/name, else reconstruct from `PersonaProfile` — age unknown → 0,
+  prompt renders "—"). Never assume the source batch still exists.
+
+## Panel (cohort) synthesis chat
+
+`PanelChat` + `chatWithPanelAction` → `ChatWithPanelUseCase` →
+`chatWithPanelStream` → `ChatPromptCompiler.compilePanelMessages`. It answers
+"what would our users think of X?" grounded in ALL responses + the
+`ArtifactSynthesis`. No persona identity — it's a research-synthesis voice.
+VPS route: `POST /api/vps/chat-with-panel` (mirrors chat-with-persona).
+
+## Local vs VPS
+
+`shouldRunLocally()` (FORCE_LOCAL=true) runs use cases in-process; otherwise
+actions POST to `${VPS_BACKEND_URL}/api/vps/...`. Backend changes require a
+VPS pull + `npx pm2 restart` before remote mode reflects them.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-markdown": "^10.1.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",

--- a/src/actions/chatWithPanel.ts
+++ b/src/actions/chatWithPanel.ts
@@ -1,28 +1,33 @@
 "use server"
 
-import { ChatWithPersonaUseCase } from "@/application/usecases/ChatWithPersonaUseCase";
+import { ChatWithPanelUseCase } from "@/application/usecases/ChatWithPanelUseCase";
 import { LlmServiceImpl } from "@/infrastructure/adapters/LlmServiceImpl";
-import { Persona } from "@/domain/entities/Persona";
-import { ChatAnalysisContext } from "@/domain/ports/LlmServicePort";
+import type { PersonaResponse } from "@/domain/entities/PersonaResponse";
+import type { ArtifactSynthesis } from "@/domain/entities/ArtifactSynthesis";
 
 import { createStreamableValue } from "@ai-sdk/rsc";
 
 import { shouldRunLocally, VPS_BACKEND_URL, getVpsAuthToken } from "@/infrastructure/config";
 
+interface ChatHistoryEntry {
+  role: 'user' | 'assistant'
+  content: string
+}
+
 async function runLocally(
-  persona: Persona,
-  analysis: ChatAnalysisContext,
+  responses: PersonaResponse[],
+  synthesis: ArtifactSynthesis | null,
   message: string,
-  history: { role: 'user' | 'assistant', content: string }[]
+  history: ChatHistoryEntry[],
 ) {
-  const stream = createStreamableValue<any>("");
+  const stream = createStreamableValue<string | { step: string; error: string }>("");
 
   (async () => {
     try {
       const llmService = LlmServiceImpl.createFromEnv("openrouter");
-      const useCase = new ChatWithPersonaUseCase(llmService);
+      const useCase = new ChatWithPanelUseCase(llmService);
 
-      const responseStream = useCase.executeStream(persona, analysis, message, history);
+      const responseStream = useCase.executeStream(responses, synthesis, message, history);
 
       let fullText = "";
       for await (const chunk of responseStream) {
@@ -32,7 +37,7 @@ async function runLocally(
 
       stream.done(fullText);
     } catch (error) {
-      console.error("Error in chatWithPersonaAction:", error);
+      console.error("Error in chatWithPanelAction:", error);
       stream.done({ step: "ERROR", error: (error as Error).message });
     }
   })();
@@ -41,22 +46,22 @@ async function runLocally(
 }
 
 async function runRemote(
-  persona: Persona,
-  analysis: ChatAnalysisContext,
+  responses: PersonaResponse[],
+  synthesis: ArtifactSynthesis | null,
   message: string,
-  history: { role: 'user' | 'assistant', content: string }[]
+  history: ChatHistoryEntry[],
 ) {
-  const stream = createStreamableValue<any>("");
+  const stream = createStreamableValue<string | { step: string; error: string }>("");
 
   (async () => {
     try {
-      const res = await fetch(`${VPS_BACKEND_URL}/api/vps/chat-with-persona`, {
+      const res = await fetch(`${VPS_BACKEND_URL}/api/vps/chat-with-panel`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${getVpsAuthToken()}`,
         },
-        body: JSON.stringify({ persona, analysis, message, history }),
+        body: JSON.stringify({ responses, synthesis, message, history }),
       });
 
       if (!res.ok) {
@@ -78,7 +83,7 @@ async function runRemote(
 
       stream.done(fullText);
     } catch (error) {
-      console.error("Error in remote chatWithPersona:", error);
+      console.error("Error in remote chatWithPanel:", error);
       stream.done({ step: "ERROR", error: (error as Error).message });
     }
   })();
@@ -86,12 +91,16 @@ async function runRemote(
   return { streamData: stream.value };
 }
 
-export async function chatWithPersonaAction(
-  persona: Persona,
-  analysis: ChatAnalysisContext,
+/**
+ * Panel synthesis chat — question the whole cohort at once. Grounds the
+ * answer in every persona's simulation response + the cross-persona synthesis.
+ */
+export async function chatWithPanelAction(
+  responses: PersonaResponse[],
+  synthesis: ArtifactSynthesis | null,
   message: string,
-  history: { role: 'user' | 'assistant', content: string }[]
+  history: ChatHistoryEntry[],
 ) {
-  if (shouldRunLocally()) return runLocally(persona, analysis, message, history);
-  return runRemote(persona, analysis, message, history);
+  if (shouldRunLocally()) return runLocally(responses, synthesis, message, history);
+  return runRemote(responses, synthesis, message, history);
 }

--- a/src/app/(app)/dashboard/simulations/[id]/page.tsx
+++ b/src/app/(app)/dashboard/simulations/[id]/page.tsx
@@ -2,14 +2,19 @@
 
 import { use, useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import { useSimulationStore } from '@/ui/stores/simulationStore'
+import { usePersonaStore } from '@/ui/stores/personaStore'
 import { useRouter } from 'next/navigation'
 import { getSimulationResultAction } from '@/actions/getSimulationResult'
 import { getProgressAction } from '@/actions/getProgress'
 import { StepIndicator } from '@/components/custom/StepIndicator'
-import { ArrowLeftIcon, ClockIcon, CheckCircleIcon, XCircleIcon, ThumbsUpIcon, ThumbsDownIcon, AlertTriangleIcon, ChevronDownIcon, ChevronRightIcon, UsersIcon } from 'lucide-react'
+import { ArrowLeftIcon, ClockIcon, CheckCircleIcon, XCircleIcon, ThumbsUpIcon, ThumbsDownIcon, AlertTriangleIcon, ChevronDownIcon, ChevronRightIcon, UsersIcon, MessageCircleIcon } from 'lucide-react'
+import type { Persona } from '@/domain/entities/Persona'
 import type { PersonaResponse } from '@/domain/entities/PersonaResponse'
 import type { MajorFinding } from '@/domain/entities/MajorFinding'
 import { computeSynthesis } from '@/ui/dashboard/utils/computeSynthesis'
+import { resolveChatPersona } from '@/ui/dashboard/utils/resolveChatPersona'
+import { PersonaChat } from '@/ui/dashboard/components/chat/PersonaChat'
+import { PanelChat } from '@/ui/dashboard/components/chat/PanelChat'
 
 const ANALYSIS_STEPS = [
   { title: 'Starting', description: 'Initializing analysis' },
@@ -372,6 +377,9 @@ function CompletedView({
 }) {
   const analyses = simulation.analyses as PersonaResponse[] | undefined
   const [expandedPersonas, setExpandedPersonas] = useState<Set<number>>(new Set())
+  const [chatTarget, setChatTarget] = useState<{ persona: Persona; analysis: PersonaResponse } | null>(null)
+  const [isPanelChatOpen, setIsPanelChatOpen] = useState(false)
+  const batches = usePersonaStore((s) => s.batches)
 
   const synthesis = useMemo(
     () => {
@@ -381,6 +389,13 @@ function CompletedView({
       return computeSynthesis(analyses)
     },
     [analyses, simulation.synthesis]
+  )
+
+  // Resolve each response back to a full Persona once — chat needs the
+  // psychometrics/backstory, not just the display projection.
+  const resolvedPersonas = useMemo(
+    () => (analyses ?? []).map((a) => resolveChatPersona(a, batches)),
+    [analyses, batches]
   )
 
   const togglePersona = (index: number) => {
@@ -406,11 +421,20 @@ function CompletedView({
       {synthesis && (
         <div className="flex flex-col gap-6">
           {/* Persona completion status */}
-          <div className="flex items-center gap-4 text-sm text-muted-foreground">
-            <span>Completed: {synthesis.completedCount}/{synthesis.totalPersonaCount}</span>
-            {synthesis.failedCount > 0 && (
-              <span className="text-destructive">Failed: {synthesis.failedCount}</span>
-            )}
+          <div className="flex flex-col sm:flex-row sm:items-center gap-3">
+            <div className="flex items-center gap-4 text-sm text-muted-foreground">
+              <span>Completed: {synthesis.completedCount}/{synthesis.totalPersonaCount}</span>
+              {synthesis.failedCount > 0 && (
+                <span className="text-destructive">Failed: {synthesis.failedCount}</span>
+              )}
+            </div>
+            <button
+              onClick={() => setIsPanelChatOpen(true)}
+              className="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-primary px-4 text-xs font-semibold text-primary-foreground transition-colors hover:bg-primary/90 w-fit"
+            >
+              <UsersIcon className="h-3.5 w-3.5" />
+              Ask the whole audience
+            </button>
           </div>
 
           {/* Research Question Answer */}
@@ -494,6 +518,7 @@ function CompletedView({
           {analyses.map((analysis, index) => {
             const personaName = analysis.personaProfile?.name ?? `Persona ${index + 1}`
             const isExpanded = expandedPersonas.has(index)
+            const chatPersona = resolvedPersonas[index]
 
             return (
             <div
@@ -528,6 +553,15 @@ function CompletedView({
 
               {isExpanded && (
                 <div className="px-4 pb-4 flex flex-col gap-4">
+                  {chatPersona && (
+                    <button
+                      onClick={() => setChatTarget({ persona: chatPersona, analysis })}
+                      className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-border bg-background px-4 text-xs font-semibold text-foreground transition-colors hover:bg-muted/40 w-fit"
+                    >
+                      <MessageCircleIcon className="h-3.5 w-3.5" />
+                      Ask {personaName} about what they saw
+                    </button>
+                  )}
                   {analysis.personaProfile && <PersonaIdentityCard profile={analysis.personaProfile} />}
 
                   {analysis.overview && (
@@ -616,6 +650,23 @@ function CompletedView({
           />
         </div>
       )}
+
+      {chatTarget && (
+        <PersonaChat
+          persona={chatTarget.persona}
+          analysis={chatTarget.analysis}
+          isOpen={!!chatTarget}
+          onClose={() => setChatTarget(null)}
+        />
+      )}
+
+      <PanelChat
+        responses={analyses}
+        synthesis={synthesis}
+        personaNames={simulation.personaNames ?? []}
+        isOpen={isPanelChatOpen}
+        onClose={() => setIsPanelChatOpen(false)}
+      />
     </div>
   )
 }

--- a/src/app/api/vps/chat-with-panel/__tests__/route.test.ts
+++ b/src/app/api/vps/chat-with-panel/__tests__/route.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { collectStream } from "../../__tests__/test-utils";
+
+const mockChatWithPanelExecuteStream = vi.hoisted(() => vi.fn());
+
+vi.mock("@/infrastructure/adapters/LlmServiceImpl", () => {
+  const LlmServiceImpl = class {
+    static createFromEnv = vi.fn(() => new LlmServiceImpl());
+  };
+  return { LlmServiceImpl };
+});
+
+vi.mock("@/application/usecases/ChatWithPanelUseCase", () => ({
+  ChatWithPanelUseCase: class {
+    executeStream = mockChatWithPanelExecuteStream;
+  },
+}));
+
+function buildResponse() {
+  return {
+    id: "r-1",
+    screenshotBase64: "iVBOR...",
+    rawAnalysis: "raw stream",
+    overview: "Sarah found the pricing clear.",
+    customerJourney: [
+      { stage: "interpretation", description: "d", sentiment: "neutral", outcome: "succeeded" },
+      { stage: "understanding", description: "d", sentiment: "positive", outcome: "succeeded" },
+      { stage: "belief", description: "d", sentiment: "neutral", outcome: "succeeded" },
+      { stage: "motivation", description: "d", sentiment: "positive", outcome: "succeeded" },
+      { stage: "action", description: "d", sentiment: "negative", outcome: "blocked" },
+    ],
+    researchQuestionAnswer: "Pricing visibility is the blocker.",
+    majorFindings: [],
+    pointsOfFriction: [],
+    unansweredQuestions: [],
+    personaProfile: {
+      name: "Sarah Chen",
+      occupation: "Senior Engineer",
+      bigFive: { conscientiousness: 80, neuroticism: 30, openness: 70, extraversion: 50, agreeableness: 60 },
+      values: ["Transparency"],
+      fears: ["Hidden costs"],
+      communicationStyle: "direct",
+      decisionStyle: "data-driven",
+    },
+  };
+}
+
+describe("POST /api/vps/chat-with-panel", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("streams a panel synthesis response", async () => {
+    mockChatWithPanelExecuteStream.mockImplementation(async function* () {
+      yield "A monthly plan would remove the blocker for most of your personas.";
+    });
+
+    const { POST } = await import("../route");
+    const req = new NextRequest(
+      "http://localhost:3000/api/vps/chat-with-panel",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          responses: [buildResponse()],
+          synthesis: null,
+          message: "We're thinking of adding a monthly plan — what would you all think?",
+          history: [],
+        }),
+      },
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/plain");
+
+    const text = await collectStream(res.body!);
+    expect(text).toBe("A monthly plan would remove the blocker for most of your personas.");
+    expect(mockChatWithPanelExecuteStream).toHaveBeenCalledWith(
+      [expect.objectContaining({ id: "r-1" })],
+      null,
+      "We're thinking of adding a monthly plan — what would you all think?",
+      [],
+    );
+  });
+
+  it("defaults missing responses and synthesis to empty/null", async () => {
+    mockChatWithPanelExecuteStream.mockImplementation(async function* () {
+      yield "ok";
+    });
+
+    const { POST } = await import("../route");
+    const req = new NextRequest("http://localhost:3000/api/vps/chat-with-panel", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "Hello", history: [] }),
+    });
+    const res = await POST(req);
+    const text = await collectStream(res.body!);
+    expect(text).toBe("ok");
+    expect(mockChatWithPanelExecuteStream).toHaveBeenCalledWith([], null, "Hello", []);
+  });
+});

--- a/src/app/api/vps/chat-with-panel/route.ts
+++ b/src/app/api/vps/chat-with-panel/route.ts
@@ -1,0 +1,55 @@
+// ─── POST /api/vps/chat-with-panel (text streaming) ────────────────────────
+// Streams a panel-synthesis chat response token by token via a ReadableStream.
+// The client receives progressively longer plain-text chunks — each chunk is
+// the entire response accumulated so far, so the UI can show the growing
+// reply in real time. Grounded in the full cohort's simulation responses plus
+// the cross-persona synthesis.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { NextRequest } from "next/server";
+import { ChatWithPanelUseCase } from "@/application/usecases/ChatWithPanelUseCase";
+import { LlmServiceImpl } from "@/infrastructure/adapters/LlmServiceImpl";
+
+export async function POST(req: NextRequest) {
+  const { responses, synthesis, message, history } = await req.json();
+
+  const llmService = LlmServiceImpl.createFromEnv("openrouter");
+  const useCase = new ChatWithPanelUseCase(llmService);
+  const responseStream = useCase.executeStream(
+    responses ?? [],
+    synthesis || null,
+    message,
+    history ?? [],
+  );
+
+  const encoder = new TextEncoder();
+  const readableStream = new ReadableStream({
+    async start(controller) {
+      try {
+        let fullText = "";
+        for await (const chunk of responseStream) {
+          fullText += chunk;
+          controller.enqueue(encoder.encode(fullText));
+        }
+        controller.close();
+      } catch (error) {
+        console.error("[chat-with-panel] Stream error:", error);
+        controller.enqueue(
+          encoder.encode(
+            JSON.stringify({
+              step: "ERROR",
+              error: (error as Error).message,
+            }),
+          ),
+        );
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(readableStream, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/src/application/usecases/ChatWithPanelUseCase.ts
+++ b/src/application/usecases/ChatWithPanelUseCase.ts
@@ -1,0 +1,22 @@
+import { PersonaResponse } from "@/domain/entities/PersonaResponse";
+import { ArtifactSynthesis } from "@/domain/entities/ArtifactSynthesis";
+import { LlmServicePort } from "@/domain/ports/LlmServicePort";
+
+/**
+ * Panel synthesis chat — the user questions the whole cohort at once and gets
+ * an answer grounded in every persona's simulation response plus the
+ * cross-persona synthesis. Distinct from ChatWithPersonaUseCase: no single
+ * persona identity; the voice is a research synthesizer.
+ */
+export class ChatWithPanelUseCase {
+  constructor(private llmService: LlmServicePort) { }
+
+  executeStream(
+    responses: PersonaResponse[],
+    synthesis: ArtifactSynthesis | null,
+    message: string,
+    history: { role: 'user' | 'assistant', content: string }[],
+  ): AsyncIterable<string> {
+    return this.llmService.chatWithPanelStream(responses, synthesis, message, history);
+  }
+}

--- a/src/application/usecases/ChatWithPersonaUseCase.ts
+++ b/src/application/usecases/ChatWithPersonaUseCase.ts
@@ -1,5 +1,5 @@
 import { Persona } from "@/domain/entities/Persona";
-import { PricingAnalysis } from "@/domain/entities/PricingAnalysis";
+import { ChatAnalysisContext } from "@/domain/ports/LlmServicePort";
 import { LlmServicePort } from "@/domain/ports/LlmServicePort";
 
 export class ChatWithPersonaUseCase {
@@ -7,7 +7,7 @@ export class ChatWithPersonaUseCase {
 
   async execute(
     persona: Persona,
-    analysis: PricingAnalysis | null,
+    analysis: ChatAnalysisContext,
     message: string,
     history: { role: 'user' | 'assistant', content: string }[]
   ): Promise<string> {
@@ -16,7 +16,7 @@ export class ChatWithPersonaUseCase {
 
   executeStream(
     persona: Persona,
-    analysis: PricingAnalysis | null,
+    analysis: ChatAnalysisContext,
     message: string,
     history: { role: 'user' | 'assistant', content: string }[]
   ): AsyncIterable<string> {

--- a/src/domain/ports/LlmServicePort.ts
+++ b/src/domain/ports/LlmServicePort.ts
@@ -1,6 +1,7 @@
 import { Persona } from "../entities/Persona";
 import { PricingAnalysis } from "../entities/PricingAnalysis";
 import { PersonaResponse } from "../entities/PersonaResponse";
+import { ArtifactSynthesis } from "../entities/ArtifactSynthesis";
 import { ArtifactIntake } from "../entities/ArtifactIntake";
 import { StreamOfConsciousness } from "../entities/StreamOfConsciousness";
 import { ExtractedInterviewSignals } from "@/application/interviewPipeline/types";
@@ -33,6 +34,16 @@ export interface PricingLocation {
     anchorText?: string;
     reasoning?: string;
 }
+
+/**
+ * Context a persona chat can be grounded in.
+ *
+ * `PricingAnalysis` is the legacy pricing-era type (kept for backward
+ * compatibility with the old results flow); `PersonaResponse` is the modern
+ * artifact-agnostic type produced by simulations — it is what "chat with a
+ * persona about what they saw" is grounded in.
+ */
+export type ChatAnalysisContext = PricingAnalysis | PersonaResponse | null;
 
 export interface LlmServicePort {
     /**
@@ -136,7 +147,7 @@ export interface LlmServicePort {
      */
     chatWithPersona(
         persona: Persona,
-        analysis: PricingAnalysis | null,
+        analysis: ChatAnalysisContext,
         message: string,
         history: { role: "user" | "assistant"; content: string }[],
     ): Promise<string>;
@@ -151,7 +162,25 @@ export interface LlmServicePort {
      */
     chatWithPersonaStream(
         persona: Persona,
-        analysis: PricingAnalysis | null,
+        analysis: ChatAnalysisContext,
+        message: string,
+        history: { role: "user" | "assistant"; content: string }[],
+    ): AsyncIterable<string>;
+
+    /**
+     * Chat with the whole cohort at once (panel synthesis). Grounds the
+     * answer in every persona's simulation response plus the cross-persona
+     * synthesis, so questions like "what would our users think of X?" get an
+     * evidence-backed synthesis rather than a single persona's take.
+     * @param responses All persona responses from the simulation.
+     * @param synthesis The cross-persona synthesis (may be null if unavailable).
+     * @param message The user's message.
+     * @param history The chat history.
+     * @returns An AsyncIterable extending string pieces.
+     */
+    chatWithPanelStream(
+        responses: PersonaResponse[],
+        synthesis: ArtifactSynthesis | null,
         message: string,
         history: { role: "user" | "assistant"; content: string }[],
     ): AsyncIterable<string>;

--- a/src/infrastructure/adapters/ChatAdapter.ts
+++ b/src/infrastructure/adapters/ChatAdapter.ts
@@ -1,5 +1,7 @@
 import { Persona } from "@/domain/entities/Persona";
-import { PricingAnalysis } from "@/domain/entities/PricingAnalysis";
+import type { PersonaResponse } from "@/domain/entities/PersonaResponse";
+import type { ArtifactSynthesis } from "@/domain/entities/ArtifactSynthesis";
+import { ChatAnalysisContext } from "@/domain/ports/LlmServicePort";
 import { LlmServiceImpl } from "./LlmServiceImpl";
 import { ChatPromptCompiler } from "./ChatPromptCompiler";
 import { IdRagStore } from "./IdRagStore";
@@ -29,7 +31,7 @@ export class ChatAdapter {
    */
   async * chatWithPersonaStream(
     persona: Persona,
-    analysis: PricingAnalysis | null,
+    analysis: ChatAnalysisContext,
     message: string,
     history: { role: "user" | "assistant"; content: string }[],
   ): AsyncIterable<string> {
@@ -103,6 +105,32 @@ export class ChatAdapter {
     } catch (err) {
       console.error("[ChatAdapter] Guardrail check failed:", err);
       return { isValid: true };
+    }
+  }
+
+  /**
+   * Panel synthesis chat — one question, grounded in the whole cohort.
+   * No persona identity/anchoring (it's a research-synthesis voice, not a
+   * single persona); just the compiled panel prompt streamed token by token.
+   */
+  async *chatWithPanelStream(
+    responses: PersonaResponse[],
+    synthesis: ArtifactSynthesis | null,
+    message: string,
+    history: { role: "user" | "assistant"; content: string }[],
+  ): AsyncIterable<string> {
+    const messages = this.chatPromptCompiler.compilePanelMessages({
+      responses,
+      synthesis,
+      message,
+      history,
+    });
+
+    for await (const chunk of this.llmService.createChatCompletionStream(messages, {
+      temperature: 0.7,
+      purpose: "Panel Synthesis Chat",
+    })) {
+      yield chunk;
     }
   }
 }

--- a/src/infrastructure/adapters/ChatPromptCompiler.ts
+++ b/src/infrastructure/adapters/ChatPromptCompiler.ts
@@ -1,15 +1,24 @@
 import { Persona } from "@/domain/entities/Persona";
-import { PricingAnalysis } from "@/domain/entities/PricingAnalysis";
+import { PersonaResponse } from "@/domain/entities/PersonaResponse";
+import { ArtifactSynthesis } from "@/domain/entities/ArtifactSynthesis";
+import { ChatAnalysisContext } from "@/domain/ports/LlmServicePort";
 import { PersonaPromptCompiler } from "./PersonaPromptCompiler";
 import OpenAI from "openai";
 
 export interface ChatPromptParams {
   persona: Persona;
-  analysis: PricingAnalysis | null;
+  analysis: ChatAnalysisContext;
   message: string;
   history: { role: "user" | "assistant"; content: string }[];
   ragContext: { contextString: string; chunkCount: number };
   needsRegrounding: boolean;
+}
+
+export interface PanelChatPromptParams {
+  responses: PersonaResponse[];
+  synthesis: ArtifactSynthesis | null;
+  message: string;
+  history: { role: "user" | "assistant"; content: string }[];
 }
 
 export class ChatPromptCompiler {
@@ -48,21 +57,30 @@ export class ChatPromptCompiler {
     ];
   }
 
-  private buildAnalysisContext(analysis: PricingAnalysis | null): string {
-    return analysis
-      ? `\nCONTEXT OF YOUR RECENT PRICING ANALYSIS:\n` +
-          `Structured Insights: ${JSON.stringify(
-            {
-              gutReaction: analysis.gutReaction,
-              scores: analysis.scores,
-              risks: analysis.risks,
-            },
-            null,
-            2,
-          )}\n` +
-          `Your Raw Thoughts During Analysis: "${analysis.rawAnalysis || analysis.thoughts}"\n\n` +
-          `A developer is interviewing you about your thoughts on this pricing page.`
-      : `\nYou are currently chatting with a developer who wants to get to know you better before showing you a pricing page for evaluation.`;
+  private buildAnalysisContext(analysis: ChatAnalysisContext): string {
+    if (!analysis) {
+      return `\nYou are currently chatting with a developer who wants to get to know you better before showing you a website for evaluation.`;
+    }
+
+    if (isPersonaResponse(analysis)) {
+      return buildPersonaResponseContext(analysis);
+    }
+
+    // Legacy pricing-analysis grounding — kept for the old results flow.
+    return (
+      `\nCONTEXT OF YOUR RECENT ANALYSIS:\n` +
+      `Structured Insights: ${JSON.stringify(
+        {
+          gutReaction: analysis.gutReaction,
+          scores: analysis.scores,
+          risks: analysis.risks,
+        },
+        null,
+        2,
+      )}\n` +
+      `Your Raw Thoughts During Analysis: "${analysis.rawAnalysis || analysis.thoughts}"\n\n` +
+      `A developer is interviewing you about your thoughts on this page.`
+    );
   }
 
   private buildRegroundingInstruction(persona: Persona, needsRegrounding: boolean): string {
@@ -90,4 +108,128 @@ CORE INSTRUCTIONS:
 4. <% "statement" | "backstory memory explaining why" %> — Use this syntax when referencing your past.
 STAY IN CHARACTER.`;
   }
+
+  /**
+   * Panel synthesis chat — the user questions the whole cohort at once.
+   * Grounds every answer in the personas' actual simulation responses and the
+   * cross-persona synthesis, so "what would our users think of X?" gets an
+   * evidence-backed answer, not a guess.
+   */
+  compilePanelMessages(params: PanelChatPromptParams): OpenAI.Chat.ChatCompletionMessageParam[] {
+    const { responses, synthesis, message, history } = params;
+
+    const personaSection = responses
+      .map((r) => {
+        const name = r.personaProfile?.name ?? r.id;
+        const lines = [
+          `--- ${name} (${r.personaProfile?.occupation ?? "unknown role"}) ---`,
+          `Overview: ${r.overview || "—"}`,
+        ];
+        if (r.customerJourney?.length) {
+          lines.push(`Journey: ${r.customerJourney.map((s) => `${s.stage} (${s.sentiment}, ${s.outcome})`).join(" → ")}`);
+        }
+        if (r.majorFindings?.length) {
+          lines.push(`Findings: ${r.majorFindings.map((f) => f.observation).join("; ")}`);
+        }
+        if (r.pointsOfFriction?.length) {
+          lines.push(`Friction: ${r.pointsOfFriction.join("; ")}`);
+        }
+        if (r.unansweredQuestions?.length) {
+          lines.push(`Open questions: ${r.unansweredQuestions.join("; ")}`);
+        }
+        return lines.join("\n");
+      })
+      .join("\n\n");
+
+    const synthesisSection = synthesis
+      ? [
+          `TOP CROSS-PERSONA FINDINGS:`,
+          ...synthesis.topFindings.slice(0, 5).map(
+            (f) => `- ${f.observation} (${f.confidence}; ${f.affectedPersonaCount}/${f.totalPersonaCount} personas) — ${f.evidence}`,
+          ),
+          synthesis.disagreements?.length
+            ? `DISAGREEMENTS: ${synthesis.disagreements.map((d) => `${d.topic} (${d.split.map((s) => `${s.personaCount} ${s.personaCount === 1 ? "persona" : "personas"}: ${s.view}`).join(", ")})`).join("; ")}`
+            : null,
+          synthesis.biggestFrictions?.length
+            ? `BIGGEST FRICTIONS: ${synthesis.biggestFrictions.join("; ")}`
+            : null,
+          synthesis.researchQuestionAnswer
+            ? `RESEARCH QUESTION ANSWER: ${synthesis.researchQuestionAnswer}`
+            : null,
+        ]
+          .filter(Boolean)
+          .join("\n")
+      : "";
+
+    const system = `You are a user-research synthesizer for a product team. A cohort of AI personas just
+interacted with the team's product and reported what they saw, felt, and did.
+Your job: answer the team's questions by SYNTHESIZING across the whole cohort —
+name patterns, surface disagreements, and say what it means for the product.
+
+Rules:
+1. GROUND: Every claim must trace back to the persona responses below. Quote or name personas when you cite them. If the cohort is silent on something, say so instead of inventing.
+2. SYNTHESIZE: Weigh how many personas shared a reaction — a pattern across several beats a single strong opinion.
+3. ACTION: End with what the team should do about it (fix, test, or ask further).
+4. VOICE: Clear, direct, plain language. No marketing fluff, no generic AI filler.
+
+<<COHORT RESPONSES>>
+${personaSection}
+
+${synthesisSection}
+`;
+
+    return [
+      { role: "system", content: system },
+      ...(history as OpenAI.Chat.ChatCompletionMessageParam[]),
+      { role: "user", content: message },
+    ];
+  }
+}
+
+/** Narrow a chat context to the modern simulation-response type. */
+function isPersonaResponse(analysis: ChatAnalysisContext): analysis is PersonaResponse {
+  return !!analysis && "customerJourney" in analysis;
+}
+
+/**
+ * "What you saw" grounding — renders a persona's own simulation response as
+ * first-person context so the chat can talk about the artifact they just
+ * experienced, not generic personality.
+ */
+function buildPersonaResponseContext(analysis: PersonaResponse): string {
+  const journey =
+    analysis.customerJourney?.length
+      ? analysis.customerJourney
+          .map(
+            (s) =>
+              `- ${s.stage}: ${s.description} (felt ${s.sentiment}, ${s.outcome})` +
+              (s.transition ? ` — ${s.transition}` : ""),
+          )
+          .join("\n")
+      : "—";
+
+  const findings = analysis.majorFindings?.length
+    ? analysis.majorFindings.map((f) => `- ${f.observation} (${f.evidence}; ${f.impact})`).join("\n")
+    : "—";
+
+  const frictions = analysis.pointsOfFriction?.length
+    ? analysis.pointsOfFriction.map((f) => `- ${f}`).join("\n")
+    : "—";
+
+  const questions = analysis.unansweredQuestions?.length
+    ? analysis.unansweredQuestions.map((q) => `- ${q}`).join("\n")
+    : "—";
+
+  return (
+    `\nCONTEXT OF WHAT YOU JUST EXPERIENCED IN THE SIMULATION:\n` +
+    `Your overall takeaway: "${analysis.overview || "—"}"\n\n` +
+    `Your journey through the artifact:\n${journey}\n\n` +
+    `What you noticed:\n${findings}\n\n` +
+    `Where you got stuck / what bothered you:\n${frictions}\n\n` +
+    `Questions you still have:\n${questions}\n\n` +
+    (analysis.researchQuestionAnswer
+      ? `Your direct answer to the research question: "${analysis.researchQuestionAnswer}"\n\n`
+      : "") +
+    `A developer is interviewing you about what you just saw and experienced. Answer as yourself — react to your own experience, not a script.`
+  );
 }

--- a/src/infrastructure/adapters/ChatPromptCompiler.ts
+++ b/src/infrastructure/adapters/ChatPromptCompiler.ts
@@ -162,15 +162,34 @@ STAY IN CHARACTER.`;
       : "";
 
     const system = `You are a user-research synthesizer for a product team. A cohort of AI personas just
-interacted with the team's product and reported what they saw, felt, and did.
+interacted with the team's product in a SIMULATION and reported what they saw, felt, and did.
 Your job: answer the team's questions by SYNTHESIZING across the whole cohort —
 name patterns, surface disagreements, and say what it means for the product.
 
+EPISTEMIC BOUNDARY (non-negotiable):
+The personas are SIMULATED users. Their reports describe what the simulated cohort
+experienced — NOT empirical measurements of what real users will do or buy. Never
+present a simulated reaction as evidence about real-world behavior. Never claim that
+fixing X will increase real conversion, signups, or revenue unless you explicitly
+frame it as a hypothesis to test. When you make a recommendation, say what to TEST,
+not what is true.
+
+Structure every substantive answer in FOUR LAYERS:
+1. FINDING — what the cohort observed (e.g. "Pricing ambiguity was the most consistent friction").
+2. EVIDENCE — who said it and how many (e.g. "6/6 personas raised pricing; Taylor called the
+   unanswered FAQ 'a red flag'"). Quote or name personas. If the cohort is silent on something,
+   say so instead of inventing.
+3. INTERPRETATION — what this likely means for the product, clearly labeled as interpretation.
+4. VALIDATION — what this does NOT establish, and what to test next (e.g. "This is a hypothesis:
+   rerun the simulation with clear pricing, or validate with real users"). Include this layer
+   whenever you recommend an action.
+
 Rules:
-1. GROUND: Every claim must trace back to the persona responses below. Quote or name personas when you cite them. If the cohort is silent on something, say so instead of inventing.
-2. SYNTHESIZE: Weigh how many personas shared a reaction — a pattern across several beats a single strong opinion.
-3. ACTION: End with what the team should do about it (fix, test, or ask further).
-4. VOICE: Clear, direct, plain language. No marketing fluff, no generic AI filler.
+1. GROUND: Every claim must trace back to the persona responses below. Name personas when you cite them. If the cohort is silent, say so.
+2. WEIGH: A pattern across several personas beats a single strong opinion. Report counts (x/y).
+3. DISSENT: Actively surface minority and dissenting views. Don't flatten disagreement into consensus — if the cohort split, say how.
+4. HONESTY: Distinguish "we know" (what the simulated cohort reported) from "we don't know" (what real users would do). Say "I don't know" when the responses don't cover it.
+5. VOICE: Clear, direct, plain language. No marketing fluff, no generic AI filler.
 
 <<COHORT RESPONSES>>
 ${personaSection}

--- a/src/infrastructure/adapters/LlmServiceImpl.ts
+++ b/src/infrastructure/adapters/LlmServiceImpl.ts
@@ -1,6 +1,6 @@
 import OpenAI from "openai";
 import pLimit from "p-limit";
-import { LlmServicePort, PricingLocation, PersonaPhaseCallback } from "@/domain/ports/LlmServicePort";
+import { LlmServicePort, PricingLocation, PersonaPhaseCallback, ChatAnalysisContext } from "@/domain/ports/LlmServicePort";
 import { createOpenAI, OpenAIProvider } from "@ai-sdk/openai";
 import { PersonaAdapter } from "./PersonaAdapter";
 import { VisionAnalysisAdapter } from "./VisionAnalysisAdapter";
@@ -11,6 +11,7 @@ import { PsychographicRationalizer } from "./PsychographicRationalizer";
 import { Persona } from "@/domain/entities/Persona";
 import { PricingAnalysis } from "@/domain/entities/PricingAnalysis";
 import type { PersonaResponse } from "@/domain/entities/PersonaResponse";
+import type { ArtifactSynthesis } from "@/domain/entities/ArtifactSynthesis";
 import type { ArtifactIntake } from "@/domain/entities/ArtifactIntake";
 import { StreamOfConsciousness } from "@/domain/entities/StreamOfConsciousness";
 import { ExtractedInterviewSignals } from "@/application/interviewPipeline/types";
@@ -667,7 +668,7 @@ export class LlmServiceImpl implements LlmServicePort {
 
     async *chatWithPersonaStream(
         persona: Persona,
-        analysis: PricingAnalysis | null,
+        analysis: ChatAnalysisContext,
         message: string,
         history: { role: "user" | "assistant"; content: string }[],
     ): AsyncIterable<string> {
@@ -684,6 +685,15 @@ export class LlmServiceImpl implements LlmServicePort {
         prompt: string,
     ): Promise<{ isValid: boolean; reason?: string }> {
         return this.chatAdapter.validatePromptDomain(persona, prompt);
+    }
+
+    async *chatWithPanelStream(
+        responses: PersonaResponse[],
+        synthesis: ArtifactSynthesis | null,
+        message: string,
+        history: { role: "user" | "assistant"; content: string }[],
+    ): AsyncIterable<string> {
+        yield* this.chatAdapter.chatWithPanelStream(responses, synthesis, message, history);
     }
 
     // --- Legacy / Compatibility ---
@@ -714,7 +724,7 @@ export class LlmServiceImpl implements LlmServicePort {
 
     async chatWithPersona(
         persona: Persona,
-        analysis: PricingAnalysis | null,
+        analysis: ChatAnalysisContext,
         msg: string,
         history: any,
     ): Promise<string> {

--- a/src/infrastructure/adapters/PersonaPromptCompiler.ts
+++ b/src/infrastructure/adapters/PersonaPromptCompiler.ts
@@ -37,7 +37,7 @@ export class PersonaPromptCompiler {
     const parts: string[] = [
       "<<PERSONA IDENTITY>>",
       `Name: ${persona.name ?? "—"}`,
-      `Age: ${persona.age ?? "—"}`,
+      `Age: ${persona.age || "—"}`,
       `Occupation: ${persona.occupation ?? "—"}`,
       `Education: ${persona.educationLevel ?? "—"}`,
       `Interests: ${join(persona.interests)}`,

--- a/src/infrastructure/adapters/__tests__/ChatPromptCompiler.test.ts
+++ b/src/infrastructure/adapters/__tests__/ChatPromptCompiler.test.ts
@@ -327,6 +327,14 @@ describe("ChatPromptCompiler", () => {
 
     const system = messages[0].content as string;
     expect(system).toContain("user-research synthesizer");
+    // Epistemic discipline: simulated ≠ empirical, four-layer answers.
+    expect(system).toContain("SIMULATED users");
+    expect(system).toContain("hypothesis to test");
+    expect(system).toContain("FINDING");
+    expect(system).toContain("EVIDENCE");
+    expect(system).toContain("INTERPRETATION");
+    expect(system).toContain("VALIDATION");
+    expect(system).toContain("DISSENT");
     expect(system).toContain("Sarah Chen");
     expect(system).toContain("Wants a monthly plan");
     expect(system).toContain("No monthly option");

--- a/src/infrastructure/adapters/__tests__/ChatPromptCompiler.test.ts
+++ b/src/infrastructure/adapters/__tests__/ChatPromptCompiler.test.ts
@@ -79,10 +79,53 @@ describe("ChatPromptCompiler", () => {
     });
 
     const system = messages[0].content as string;
-    expect(system).toContain("CONTEXT OF YOUR RECENT PRICING ANALYSIS");
+    expect(system).toContain("CONTEXT OF YOUR RECENT ANALYSIS");
     expect(system).toContain("hidden fees");
     expect(system).toContain("This pricing page is confusing");
     expect(system).toContain("interviewing you about your thoughts");
+  });
+
+  it("includes simulation-response grounding when analysis is a PersonaResponse", () => {
+    const compiler = new ChatPromptCompiler();
+    const messages = compiler.compileChatMessages({
+      persona: basePersona,
+      analysis: {
+        id: "resp-1",
+        screenshotBase64: "",
+        rawAnalysis: "raw stream",
+        overview: "I found the onboarding confusing but the pricing clear.",
+        customerJourney: [
+          { stage: "interpretation", description: "I tried to figure out what this does.", sentiment: "neutral", outcome: "succeeded" },
+          { stage: "understanding", description: "The value prop clicked.", sentiment: "positive", outcome: "succeeded" },
+          { stage: "belief", description: "I started to trust it.", sentiment: "neutral", outcome: "succeeded" },
+          { stage: "motivation", description: "I wanted to sign up.", sentiment: "positive", outcome: "succeeded" },
+          { stage: "action", description: "I hit the paywall.", sentiment: "negative", outcome: "blocked", transition: "Pricing hidden until demo" },
+        ],
+        researchQuestionAnswer: "Pricing visibility is the blocker.",
+        majorFindings: [
+          { observation: "Paywall appears too early", evidence: "Hit signup wall at action stage", impact: "Drop-off" },
+        ],
+        pointsOfFriction: ["Pricing hidden"],
+        unansweredQuestions: ["What does it cost?"],
+        personaProfile: { name: "Jordan Chen", occupation: "Product Manager", bigFive: { conscientiousness: 80, neuroticism: 60, openness: 70, extraversion: 45, agreeableness: 55 }, values: ["Efficiency"], fears: ["Wasted effort"], communicationStyle: "Direct", decisionStyle: "Data-driven" },
+      },
+      message: "What did you think?",
+      history: [],
+      ragContext: { contextString: "", chunkCount: 0 },
+      needsRegrounding: false,
+    });
+
+    const system = messages[0].content as string;
+    expect(system).toContain("CONTEXT OF WHAT YOU JUST EXPERIENCED IN THE SIMULATION");
+    expect(system).toContain("I found the onboarding confusing but the pricing clear.");
+    expect(system).toContain("action: I hit the paywall. (felt negative, blocked) — Pricing hidden until demo");
+    expect(system).toContain("Paywall appears too early");
+    expect(system).toContain("Pricing hidden");
+    expect(system).toContain("What does it cost?");
+    expect(system).toContain("Pricing visibility is the blocker.");
+    expect(system).toContain("interviewing you about what you just saw and experienced");
+    // The legacy pricing branch must NOT leak into simulation grounding.
+    expect(system).not.toContain("CONTEXT OF YOUR RECENT PRICING ANALYSIS");
   });
 
   it("includes introductory framing when no analysis is provided", () => {
@@ -98,7 +141,7 @@ describe("ChatPromptCompiler", () => {
 
     const system = messages[0].content as string;
     expect(system).toContain("chatting with a developer who wants to get to know you");
-    expect(system).not.toContain("CONTEXT OF YOUR RECENT PRICING ANALYSIS");
+    expect(system).not.toContain("CONTEXT OF YOUR RECENT ANALYSIS");
   });
 
   it("includes regrounding instruction when needsRegrounding is true", () => {
@@ -243,5 +286,53 @@ describe("ChatPromptCompiler", () => {
     // The anchor for a conscientious analytical persona should produce a non-empty tag
     expect(frame).toMatch(/\[Frame: [^\]]+\]/);
     expect(frame.toLowerCase()).toContain("product manager");
+  });
+
+  it("compiles a panel synthesis prompt grounded in all responses and the synthesis", () => {
+    const compiler = new ChatPromptCompiler();
+    const messages = compiler.compilePanelMessages({
+      responses: [
+        {
+          id: "r-1",
+          screenshotBase64: "",
+          rawAnalysis: "raw",
+          overview: "Sarah found the pricing clear but wanted a monthly option.",
+          customerJourney: [
+            { stage: "interpretation", description: "d", sentiment: "neutral", outcome: "succeeded" },
+            { stage: "understanding", description: "d", sentiment: "positive", outcome: "succeeded" },
+            { stage: "belief", description: "d", sentiment: "neutral", outcome: "succeeded" },
+            { stage: "motivation", description: "d", sentiment: "positive", outcome: "succeeded" },
+            { stage: "action", description: "d", sentiment: "negative", outcome: "blocked" },
+          ],
+          researchQuestionAnswer: "Pricing visibility is the blocker.",
+          majorFindings: [{ observation: "Wants a monthly plan", evidence: "Asked at action stage", impact: "Conversion drop" }],
+          pointsOfFriction: ["No monthly option"],
+          unansweredQuestions: ["Can I pay monthly?"],
+          personaProfile: { name: "Sarah Chen", occupation: "Senior Engineer", bigFive: { conscientiousness: 80, neuroticism: 30, openness: 70, extraversion: 50, agreeableness: 60 }, values: ["Transparency"], fears: ["Hidden costs"], communicationStyle: "direct", decisionStyle: "data-driven" },
+        },
+      ],
+      synthesis: {
+        overview: "Both personas want pricing flexibility.",
+        researchQuestionAnswer: "Monthly pricing would remove the blocker.",
+        topFindings: [{ observation: "Pricing opacity blocks action", evidence: "Both paused at pricing", impact: "Drop-off", confidence: "strongly supported", affectedPersonaCount: 2, totalPersonaCount: 2 }],
+        disagreements: [],
+        biggestFrictions: ["No monthly option"],
+        completedCount: 2,
+        failedCount: 0,
+        totalPersonaCount: 2,
+      },
+      message: "We're thinking of adding a monthly plan — what would you all think?",
+      history: [],
+    });
+
+    const system = messages[0].content as string;
+    expect(system).toContain("user-research synthesizer");
+    expect(system).toContain("Sarah Chen");
+    expect(system).toContain("Wants a monthly plan");
+    expect(system).toContain("No monthly option");
+    expect(system).toContain("Pricing opacity blocks action");
+    expect(system).toContain("Monthly pricing would remove the blocker.");
+    expect(messages).toHaveLength(2); // system + user (no history)
+    expect(messages[1].role).toBe("user");
   });
 });

--- a/src/ui/dashboard/components/chat/ChatMarkdown.tsx
+++ b/src/ui/dashboard/components/chat/ChatMarkdown.tsx
@@ -1,0 +1,61 @@
+import React from "react"
+import ReactMarkdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+import remarkBreaks from "remark-breaks"
+
+/**
+ * Renders a chat message body as markdown (bold, italics, lists, links, code).
+ *
+ * Chat content arrives as plain text from the LLM — without this, `**bold**`
+ * shows literally. Two choices keep it chat-shaped:
+ *
+ * 1. `remark-breaks` — the LLM separates thoughts with single newlines, and
+ *    markdown normally collapses those into spaces. This plugin renders a
+ *    single newline as a line break, so persona replies keep their rhythm.
+ * 2. `p -> span` — react-markdown wraps text in <p>; inside a message bubble
+ *    that adds paragraph gaps between every segment. Rendering paragraphs as
+ *    spans keeps the bubble tight while still allowing block elements
+ *    (lists, code blocks) where the model actually uses them.
+ */
+export function ChatMarkdown({ content }: { content: string }) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm, remarkBreaks]}
+      components={{
+        p: ({ children }) => <span className="inline">{children}</span>,
+        a: ({ children, href }) => (
+          <a
+            href={href}
+            target="_blank"
+            rel="noreferrer"
+            className="text-primary underline underline-offset-2 hover:text-primary/80"
+          >
+            {children}
+          </a>
+        ),
+        ul: ({ children }) => <ul className="list-disc pl-5 my-1.5 space-y-1">{children}</ul>,
+        ol: ({ children }) => <ol className="list-decimal pl-5 my-1.5 space-y-1">{children}</ol>,
+        li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+        blockquote: ({ children }) => (
+          <blockquote className="border-l-2 border-border/60 pl-3 my-1.5 text-muted-foreground">
+            {children}
+          </blockquote>
+        ),
+        code: ({ children }) => (
+          <code className="rounded bg-muted px-1.5 py-0.5 text-[0.85em] font-mono">{children}</code>
+        ),
+        pre: ({ children }) => (
+          <pre className="overflow-x-auto rounded-md bg-muted p-3 my-2 text-xs font-mono leading-relaxed">
+            {children}
+          </pre>
+        ),
+        h1: ({ children }) => <h1 className="text-base font-bold mt-2 mb-1">{children}</h1>,
+        h2: ({ children }) => <h2 className="text-sm font-bold mt-2 mb-1">{children}</h2>,
+        h3: ({ children }) => <h3 className="text-sm font-semibold mt-2 mb-1">{children}</h3>,
+        strong: ({ children }) => <strong className="font-semibold text-foreground">{children}</strong>,
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  )
+}

--- a/src/ui/dashboard/components/chat/PanelChat.tsx
+++ b/src/ui/dashboard/components/chat/PanelChat.tsx
@@ -178,8 +178,8 @@ export function PanelChat({ responses, synthesis, personaNames, isOpen, onClose 
                         ? 'var(--chat-user-bubble)'
                         : 'var(--chat-assistant-bubble)',
                     }}
-                    className={`px-4 py-3 rounded-2xl text-sm leading-relaxed whitespace-pre-wrap text-foreground ${
-                      m.role === 'user' ? 'rounded-tr-sm' : 'rounded-tl-sm border border-border/40'
+                    className={`px-4 py-3 rounded-2xl text-sm leading-relaxed text-foreground ${
+                      m.role === 'user' ? 'rounded-tr-sm whitespace-pre-wrap' : 'rounded-tl-sm border border-border/40'
                     }`}
                   >
                     {parseMessageContent(m.content)}

--- a/src/ui/dashboard/components/chat/PanelChat.tsx
+++ b/src/ui/dashboard/components/chat/PanelChat.tsx
@@ -40,10 +40,26 @@ export function PanelChat({ responses, synthesis, personaNames, isOpen, onClose 
   const [input, setInput] = useState("")
   const [isPending, startTransition] = useTransition()
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  const chatRef = useRef<HTMLDivElement>(null)
 
+  // Scroll to the newest message only when the conversation changes.
+  // Runs per-token during streaming, so an instant (non-smooth) scroll keeps
+  // up with the stream; smooth scrolling here stacks animations and jitters.
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
-  })
+    const el = messagesEndRef.current
+    if (!el) return
+    const frame = requestAnimationFrame(() => {
+      el.scrollIntoView({ behavior: "auto", block: "end" })
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [messages])
+
+  // Keep the chat pane pinned to the newest message while streaming.
+  useEffect(() => {
+    const el = chatRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+  }, [isPending])
 
   const handleSend = (overrideMessage?: string) => {
     const messageToSend = (overrideMessage || input).trim()
@@ -108,7 +124,7 @@ export function PanelChat({ responses, synthesis, personaNames, isOpen, onClose 
                 <UsersIcon className="h-5 w-5" />
               </div>
               <div>
-                <DialogTitle className="text-base">Ask your whole audience</DialogTitle>
+                <DialogTitle className="text-base">Ask the simulated users</DialogTitle>
                 <DialogDescription className="text-xs">
                   One question, synthesized across {names}
                 </DialogDescription>
@@ -116,21 +132,25 @@ export function PanelChat({ responses, synthesis, personaNames, isOpen, onClose 
             </div>
           </DialogHeader>
 
-          <div className="flex-1 overflow-y-auto p-6 flex flex-col gap-6 custom-scrollbar">
+          <div
+            ref={chatRef}
+            className="flex-1 overflow-y-auto p-6 flex flex-col gap-6 custom-scrollbar"
+          >
             {messages.length === 0 ? (
               <div className="flex-1 flex flex-col items-center justify-center text-center gap-4 text-muted-foreground">
                 <div className="w-16 h-16 rounded-full bg-secondary flex items-center justify-center text-xl">
                   🎯
                 </div>
                 <p className="text-sm max-w-[280px] text-balance">
-                  Testing a new feature or message? Ask what your personas would
-                  think — get the pattern across everyone, not just one opinion.
+                  Ask the simulated users about what they experienced — what
+                  they saw, what stopped them, what they'd want changed.
                 </p>
                 <div className="flex flex-col gap-2 w-full max-w-[280px]">
                   {[
-                    "We're thinking of adding a free tier — what would you all think?",
-                    "Which part of the page turned most of you off?",
-                    "What would make you actually sign up today?",
+                    "We're thinking of adding a free tier — what would the simulated users think?",
+                    "What stopped people from signing up?",
+                    "Where did the simulated users disagree?",
+                    "Show me the dissenting opinions.",
                   ].map((suggestion) => (
                     <button
                       key={suggestion}
@@ -141,6 +161,10 @@ export function PanelChat({ responses, synthesis, personaNames, isOpen, onClose 
                     </button>
                   ))}
                 </div>
+                <p className="text-[10px] text-muted-foreground/60 max-w-[280px]">
+                  Findings describe simulated users — hypotheses to test, not
+                  proof about real users.
+                </p>
               </div>
             ) : (
               messages.map((m, i) => (

--- a/src/ui/dashboard/components/chat/PanelChat.tsx
+++ b/src/ui/dashboard/components/chat/PanelChat.tsx
@@ -1,0 +1,217 @@
+"use client"
+
+import React, { useState, useTransition, useRef, useEffect } from "react"
+import type { PersonaResponse } from "@/domain/entities/PersonaResponse"
+import type { ArtifactSynthesis } from "@/domain/entities/ArtifactSynthesis"
+import { chatWithPanelAction } from "@/actions/chatWithPanel"
+import { Send, Loader2, UsersIcon } from "lucide-react"
+import { readStreamableValue } from "@ai-sdk/rsc"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { parseMessageContent } from "./parseMessageContent"
+
+interface Message {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+interface PanelChatProps {
+  responses: PersonaResponse[]
+  synthesis: ArtifactSynthesis | null
+  personaNames: string[]
+  isOpen: boolean
+  onClose: () => void
+}
+
+/**
+ * Panel synthesis chat — question the whole cohort at once. The assistant is
+ * a research synthesizer grounded in every persona's simulation response plus
+ * the cross-persona synthesis: "we're thinking of adding X — what would our
+ * users think?" gets an evidence-backed answer across all personas.
+ */
+export function PanelChat({ responses, synthesis, personaNames, isOpen, onClose }: PanelChatProps) {
+  const [messages, setMessages] = useState<Message[]>([])
+  const [input, setInput] = useState("")
+  const [isPending, startTransition] = useTransition()
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
+  })
+
+  const handleSend = (overrideMessage?: string) => {
+    const messageToSend = (overrideMessage || input).trim()
+    if (!messageToSend || isPending) return
+
+    setInput("")
+    const newMessages: Message[] = [...messages, { role: 'user', content: messageToSend }]
+    setMessages(newMessages)
+    setMessages((prev) => [...prev, { role: 'assistant', content: '' }])
+
+    startTransition(async () => {
+      try {
+        const { streamData } = await chatWithPanelAction(
+          responses,
+          synthesis,
+          messageToSend,
+          messages
+        )
+
+        for await (const content of readStreamableValue(streamData)) {
+          if (content) {
+            // Error step delivered as object via stream.done({ step: "ERROR" })
+            if (typeof content !== 'string') {
+              const errorMsg = (content as { error?: string }).error || 'Chat failed'
+              throw new Error(errorMsg)
+            }
+            setMessages((prev) => {
+              const last = prev[prev.length - 1]
+              if (last && last.role === 'assistant') {
+                return [...prev.slice(0, -1), { role: 'assistant', content }]
+              }
+              return prev
+            })
+          }
+        }
+      } catch (error) {
+        console.error('Panel chat error:', error)
+        setMessages((prev) => {
+          const last = prev[prev.length - 1]
+          if (last && last.role === 'assistant' && last.content === '') {
+            return [...prev.slice(0, -1), { role: 'assistant', content: 'Connection lost. Please try again.' }]
+          }
+          return [...prev, { role: 'assistant', content: 'Connection lost. Please try again.' }]
+        })
+      }
+    })
+  }
+
+  const names = personaNames.length > 0
+    ? personaNames.join(', ')
+    : responses.length > 0
+      ? `${responses.length} personas`
+      : 'your audience'
+
+  return (
+    <TooltipProvider>
+      <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+        <DialogContent className="max-w-md sm:max-w-lg max-h-[85vh] flex flex-col p-0 gap-0">
+          <DialogHeader className="px-6 py-4 border-b border-border/40 shrink-0">
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <UsersIcon className="h-5 w-5" />
+              </div>
+              <div>
+                <DialogTitle className="text-base">Ask your whole audience</DialogTitle>
+                <DialogDescription className="text-xs">
+                  One question, synthesized across {names}
+                </DialogDescription>
+              </div>
+            </div>
+          </DialogHeader>
+
+          <div className="flex-1 overflow-y-auto p-6 flex flex-col gap-6 custom-scrollbar">
+            {messages.length === 0 ? (
+              <div className="flex-1 flex flex-col items-center justify-center text-center gap-4 text-muted-foreground">
+                <div className="w-16 h-16 rounded-full bg-secondary flex items-center justify-center text-xl">
+                  🎯
+                </div>
+                <p className="text-sm max-w-[280px] text-balance">
+                  Testing a new feature or message? Ask what your personas would
+                  think — get the pattern across everyone, not just one opinion.
+                </p>
+                <div className="flex flex-col gap-2 w-full max-w-[280px]">
+                  {[
+                    "We're thinking of adding a free tier — what would you all think?",
+                    "Which part of the page turned most of you off?",
+                    "What would make you actually sign up today?",
+                  ].map((suggestion) => (
+                    <button
+                      key={suggestion}
+                      onClick={() => handleSend(suggestion)}
+                      className="text-xs text-left px-3 py-2 rounded-md border border-border bg-background hover:bg-muted/40 transition-colors"
+                    >
+                      {suggestion}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              messages.map((m, i) => (
+                <div
+                  key={`${m.role}-${i}`}
+                  className={`flex flex-col max-w-[85%] ${m.role === 'user' ? 'self-end items-end' : 'self-start items-start'}`}
+                >
+                  <div
+                    style={{
+                      backgroundColor: m.role === 'user'
+                        ? 'var(--chat-user-bubble)'
+                        : 'var(--chat-assistant-bubble)',
+                    }}
+                    className={`px-4 py-3 rounded-2xl text-sm leading-relaxed whitespace-pre-wrap text-foreground ${
+                      m.role === 'user' ? 'rounded-tr-sm' : 'rounded-tl-sm border border-border/40'
+                    }`}
+                  >
+                    {parseMessageContent(m.content)}
+                  </div>
+                  <span className="text-[10px] text-muted-foreground mt-1.5 px-1">
+                    {m.role === 'user' ? 'You' : 'Synthesis'}
+                  </span>
+                </div>
+              ))
+            )}
+            {isPending && (
+              <div className="self-start flex flex-col max-w-[85%] items-start">
+                <div
+                  style={{ backgroundColor: 'var(--chat-assistant-bubble)' }}
+                  className="px-5 py-4 rounded-2xl rounded-tl-sm text-foreground border border-border/40 flex items-center gap-1.5"
+                >
+                  <div className="w-1.5 h-1.5 rounded-full bg-foreground/40 animate-[fade-in-out_1.4s_ease-in-out_infinite]" style={{ animationDelay: '0ms' }} />
+                  <div className="w-1.5 h-1.5 rounded-full bg-foreground/40 animate-[fade-in-out_1.4s_ease-in-out_infinite]" style={{ animationDelay: '467ms' }} />
+                  <div className="w-1.5 h-1.5 rounded-full bg-foreground/40 animate-[fade-in-out_1.4s_ease-in-out_infinite]" style={{ animationDelay: '933ms' }} />
+                </div>
+              </div>
+            )}
+            <div ref={messagesEndRef} />
+          </div>
+
+          <div className="p-4 bg-card border-t border-border/40 shrink-0">
+            <form
+              onSubmit={(e) => {
+                e.preventDefault()
+                handleSend()
+              }}
+              className="relative flex items-center"
+            >
+              <input
+                type="text"
+                className="w-full h-12 pl-4 pr-12 rounded-md border border-input bg-background text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-all placeholder:text-muted-foreground/70"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                placeholder="Ask the whole audience..."
+                disabled={isPending}
+              />
+              <button
+                type="submit"
+                disabled={isPending || !input || !input.trim()}
+                className="absolute right-1.5 h-9 w-9 flex items-center justify-center rounded-md bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50 disabled:pointer-events-none"
+              >
+                {isPending ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Send className="w-4 h-4" />
+                )}
+              </button>
+            </form>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </TooltipProvider>
+  )
+}

--- a/src/ui/dashboard/components/chat/PersonaChat.tsx
+++ b/src/ui/dashboard/components/chat/PersonaChat.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useTransition, useRef, useEffect } from "react"
 import { Persona } from "@/domain/entities/Persona"
 import { chatWithPersonaAction } from "@/actions/chatWithPersona"
+import type { ChatAnalysisContext } from "@/domain/ports/LlmServicePort"
 import { useLocalStorage } from "@/ui/hooks/useLocalStorage"
 import { Send, Loader2 } from "lucide-react"
 import { readStreamableValue } from "@ai-sdk/rsc"
@@ -25,9 +26,12 @@ interface PersonaChatProps {
   persona: Persona
   isOpen: boolean
   onClose: () => void
+  /** Grounding context — what the persona saw/experienced. Pass the simulation
+   *  response so chat stays anchored to the artifact they just reviewed. */
+  analysis?: ChatAnalysisContext
 }
 
-export function PersonaChat({ persona, isOpen, onClose }: PersonaChatProps) {
+export function PersonaChat({ persona, isOpen, onClose, analysis = null }: PersonaChatProps) {
   const storageKey = `persona_chat_${persona.id}`
   const [messages, setMessages] = useLocalStorage<Message[]>(storageKey, [])
   const [input, setInput] = useState("")
@@ -53,7 +57,7 @@ export function PersonaChat({ persona, isOpen, onClose }: PersonaChatProps) {
       try {
         const { streamData } = await chatWithPersonaAction(
           persona,
-          null,
+          analysis,
           messageToSend,
           messages
         )
@@ -113,7 +117,9 @@ export function PersonaChat({ persona, isOpen, onClose }: PersonaChatProps) {
                   💬
                 </div>
                 <p className="text-sm max-w-[250px] text-balance">
-                  Start a conversation with {persona.name}. Ask them about your product, pricing, or their pain points.
+                  {analysis
+                    ? `Ask ${persona.name} about what they just experienced — their reaction to your site, what stopped them, and what would have won them over.`
+                    : `Start a conversation with ${persona.name}. Ask them about your product, pricing, or their pain points.`}
                 </p>
               </div>
             ) : (

--- a/src/ui/dashboard/components/chat/PersonaChat.tsx
+++ b/src/ui/dashboard/components/chat/PersonaChat.tsx
@@ -39,9 +39,24 @@ export function PersonaChat({ persona, isOpen, onClose, analysis = null }: Perso
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const chatRef = useRef<HTMLDivElement>(null)
 
+  // Scroll to the newest message only when the conversation changes.
+  // Runs per-token during streaming, so an instant (non-smooth) scroll keeps
+  // up with the stream; smooth scrolling here stacks animations and jitters.
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
-  })
+    const el = messagesEndRef.current
+    if (!el) return
+    const frame = requestAnimationFrame(() => {
+      el.scrollIntoView({ behavior: "auto", block: "end" })
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [messages])
+
+  // Keep the chat pane pinned to the newest message while streaming.
+  useEffect(() => {
+    const el = chatRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+  }, [isPending])
 
   const handleSend = (overrideMessage?: string) => {
     const messageToSend = (overrideMessage || input).trim()

--- a/src/ui/dashboard/components/chat/PersonaChat.tsx
+++ b/src/ui/dashboard/components/chat/PersonaChat.tsx
@@ -149,8 +149,8 @@ export function PersonaChat({ persona, isOpen, onClose, analysis = null }: Perso
                       ? 'var(--chat-user-bubble)' 
                       : 'var(--chat-assistant-bubble)',
                   }}
-                  className={`px-4 py-3 rounded-2xl text-sm leading-relaxed whitespace-pre-wrap text-foreground ${
-                    m.role === 'user' ? 'rounded-tr-sm' : 'rounded-tl-sm border border-border/40'
+                  className={`px-4 py-3 rounded-2xl text-sm leading-relaxed text-foreground ${
+                    m.role === 'user' ? 'rounded-tr-sm whitespace-pre-wrap' : 'rounded-tl-sm border border-border/40'
                   }`}
                 >
                   {parseMessageContent(m.content)}

--- a/src/ui/dashboard/components/chat/PersonaChatInline.tsx
+++ b/src/ui/dashboard/components/chat/PersonaChatInline.tsx
@@ -26,9 +26,24 @@ export function PersonaChatInline({ persona }: PersonaChatInlineProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const chatRef = useRef<HTMLDivElement>(null)
 
+  // Scroll to the newest message only when the conversation changes.
+  // Runs per-token during streaming, so an instant (non-smooth) scroll keeps
+  // up with the stream; smooth scrolling here stacks animations and jitters.
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
-  })
+    const el = messagesEndRef.current
+    if (!el) return
+    const frame = requestAnimationFrame(() => {
+      el.scrollIntoView({ behavior: "auto", block: "end" })
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [messages])
+
+  // Keep the chat pane pinned to the newest message while streaming.
+  useEffect(() => {
+    const el = chatRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+  }, [isPending])
 
   const handleSend = (overrideMessage?: string) => {
     const messageToSend = (overrideMessage || input).trim()

--- a/src/ui/dashboard/components/chat/PersonaChatInline.tsx
+++ b/src/ui/dashboard/components/chat/PersonaChatInline.tsx
@@ -120,8 +120,8 @@ export function PersonaChatInline({ persona }: PersonaChatInlineProps) {
                       ? 'var(--chat-user-bubble)'
                       : 'var(--chat-assistant-bubble)',
                   }}
-                  className={`px-4 py-3 rounded-2xl text-sm leading-relaxed whitespace-pre-wrap text-foreground ${
-                    m.role === 'user' ? 'rounded-tr-sm' : 'rounded-tl-sm border border-border/40'
+                  className={`px-4 py-3 rounded-2xl text-sm leading-relaxed text-foreground ${
+                    m.role === 'user' ? 'rounded-tr-sm whitespace-pre-wrap' : 'rounded-tl-sm border border-border/40'
                   }`}
                 >
                   {parseMessageContent(m.content)}

--- a/src/ui/dashboard/components/chat/__tests__/parseMessageContent.test.tsx
+++ b/src/ui/dashboard/components/chat/__tests__/parseMessageContent.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { parseMessageContent } from "../parseMessageContent";
+
+describe("parseMessageContent", () => {
+  it("renders bold markdown instead of raw asterisks", () => {
+    const { container } = render(<div>{parseMessageContent("**pricing** is the blocker")}</div>);
+    expect(container.querySelector("strong")).not.toBeNull();
+    expect(container.textContent).toContain("pricing is the blocker");
+    // Raw asterisks must not leak through.
+    expect(container.textContent).not.toContain("**");
+  });
+
+  it("renders lists and italic markdown", () => {
+    const { container } = render(
+      <div>{parseMessageContent("1. show the price\n2. prove the claims")}</div>,
+    );
+    expect(container.querySelector("ol")).not.toBeNull();
+    expect(container.querySelector("li")).not.toBeNull();
+  });
+
+  it("preserves single newlines as line breaks (no whitespace collapse)", () => {
+    const { container } = render(<div>{parseMessageContent("line one\nline two")}</div>);
+    expect(container.textContent).toContain("line one");
+    expect(container.textContent).toContain("line two");
+    // remark-breaks keeps the line break instead of collapsing to a space.
+    expect(container.querySelector("br")).not.toBeNull();
+  });
+
+  it("extracts reasoning into a ThinkingBlock", () => {
+    const { container } = render(
+      <div>{parseMessageContent("<<REASONING>>inner plan<</REASONING>>answer")}</div>,
+    );
+    // Collapsed ThinkingBlock shows its toggle; the reasoning body is hidden.
+    expect(container.textContent).toContain("Thinking");
+    expect(container.textContent).toContain("answer");
+    // The reasoning markers themselves are consumed.
+    expect(container.textContent).not.toContain("<<REASONING>>");
+    expect(container.textContent).not.toContain("<</REASONING>>");
+  });
+
+  it("keeps memory markers as footnotes with superscript refs", () => {
+    const { container } = render(
+      <div>{parseMessageContent("I remember [Memory: my childhood dog] fondly")}</div>,
+    );
+    expect(container.querySelector("sup")).not.toBeNull();
+    expect(container.textContent).toContain("my childhood dog");
+  });
+});

--- a/src/ui/dashboard/components/chat/parseMessageContent.tsx
+++ b/src/ui/dashboard/components/chat/parseMessageContent.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip"
 import { ThinkingBlock } from "@/components/custom/ThinkingBlock"
+import { ChatMarkdown } from "./ChatMarkdown"
 
 const REASONING_REGEX = new RegExp("<<REASONING>>([\\s\\S]*?)<</REASONING>>", "g")
 
@@ -15,7 +16,7 @@ export function parseMessageContent(content: string): React.ReactNode[] {
   let lastIndex = 0
 
   const reasoningMatch = content.match(REASONING_REGEX)
-  let textWithoutReasoning = content.replace(REASONING_REGEX, "").trim()
+  const textWithoutReasoning = content.replace(REASONING_REGEX, "").trim()
 
   if (reasoningMatch) {
     const reasoningText = reasoningMatch[0].replace("<<REASONING>>", "").replace("<</REASONING>>", "").trim()
@@ -32,7 +33,9 @@ export function parseMessageContent(content: string): React.ReactNode[] {
 
   while (match !== null) {
     if (match.index > lastIndex) {
-      parts.push(textWithoutReasoning.slice(lastIndex, match.index))
+      parts.push(
+        <ChatMarkdown key={`md-${lastIndex}`} content={textWithoutReasoning.slice(lastIndex, match.index)} />
+      )
     }
 
     if (match[1]) {
@@ -76,7 +79,9 @@ export function parseMessageContent(content: string): React.ReactNode[] {
   }
 
   if (lastIndex < textWithoutReasoning.length) {
-    parts.push(textWithoutReasoning.slice(lastIndex))
+    parts.push(
+      <ChatMarkdown key={`md-${lastIndex}`} content={textWithoutReasoning.slice(lastIndex)} />
+    )
   }
 
   if (memories.length > 0) {

--- a/src/ui/dashboard/utils/__tests__/resolveChatPersona.test.ts
+++ b/src/ui/dashboard/utils/__tests__/resolveChatPersona.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { resolveChatPersona, personaFromProfile } from "../resolveChatPersona";
+import type { PersonaResponse } from "@/domain/entities/PersonaResponse";
+import type { PersonaBatch } from "@/ui/stores/personaStore";
+
+const profile = {
+  name: "Sarah Chen",
+  occupation: "Senior Engineer",
+  bigFive: { conscientiousness: 80, neuroticism: 30, openness: 70, extraversion: 50, agreeableness: 60 },
+  values: ["Transparency"],
+  fears: ["Hidden costs"],
+  communicationStyle: "direct",
+  decisionStyle: "data-driven",
+};
+
+const fullPersona = {
+  id: "persona-full",
+  name: "Sarah Chen",
+  age: 34,
+  occupation: "Senior Engineer",
+  educationLevel: "MS",
+  interests: ["sailing"],
+  goals: ["ship reliable code"],
+  conscientiousness: 80,
+  neuroticism: 30,
+  openness: 70,
+  extraversion: 50,
+  agreeableness: 60,
+  values: ["Transparency"],
+  fears: ["Hidden costs"],
+  communicationStyle: "direct",
+  decisionStyle: "data-driven",
+  backstory: "Grew up in a family of engineers.",
+};
+
+const batch: PersonaBatch = {
+  id: "batch-1",
+  label: "Q3 cohort",
+  source: "description",
+  createdAt: new Date().toISOString(),
+  personas: [fullPersona],
+};
+
+const response = (overrides: Partial<PersonaResponse> = {}): PersonaResponse => ({
+  id: "r-1",
+  screenshotBase64: "",
+  rawAnalysis: "raw",
+  overview: "Clear pricing but wanted a monthly option.",
+  customerJourney: [
+    { stage: "interpretation", description: "d", sentiment: "neutral", outcome: "succeeded" },
+    { stage: "understanding", description: "d", sentiment: "positive", outcome: "succeeded" },
+    { stage: "belief", description: "d", sentiment: "neutral", outcome: "succeeded" },
+    { stage: "motivation", description: "d", sentiment: "positive", outcome: "succeeded" },
+    { stage: "action", description: "d", sentiment: "negative", outcome: "blocked" },
+  ],
+  researchQuestionAnswer: "Monthly pricing would help.",
+  majorFindings: [],
+  pointsOfFriction: [],
+  unansweredQuestions: [],
+  personaProfile: profile,
+  ...overrides,
+});
+
+describe("resolveChatPersona", () => {
+  it("returns the full persona on exact personaId match", () => {
+    const resolved = resolveChatPersona(response({ personaId: "persona-full" }), [batch]);
+    expect(resolved).toEqual(fullPersona);
+  });
+
+  it("matches by name when personaId is missing (older runs)", () => {
+    const resolved = resolveChatPersona(response(), [batch]);
+    expect(resolved).toEqual(fullPersona);
+  });
+
+  it("matches by name across a later batch when the first batch lacks the persona", () => {
+    const emptyBatch: PersonaBatch = { ...batch, id: "other", personas: [] };
+    const resolved = resolveChatPersona(response(), [emptyBatch, batch]);
+    expect(resolved).toEqual(fullPersona);
+  });
+
+  it("falls back to a profile-derived persona when no batch holds the persona", () => {
+    const resolved = resolveChatPersona(response({ personaId: "gone" }), []);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.name).toBe("Sarah Chen");
+    expect(resolved!.occupation).toBe("Senior Engineer");
+    expect(resolved!.conscientiousness).toBe(80);
+    expect(resolved!.values).toEqual(["Transparency"]);
+    expect(resolved!.age).toBe(0); // unknown — compiler renders "—"
+  });
+
+  it("returns null when there is no profile to fall back on", () => {
+    const resolved = resolveChatPersona(response({ personaProfile: undefined }), []);
+    expect(resolved).toBeNull();
+  });
+});
+
+describe("personaFromProfile", () => {
+  it("reconstructs a chat-capable persona from the display projection", () => {
+    const p = personaFromProfile(profile, "derived-1");
+    expect(p.id).toBe("derived-1");
+    expect(p.name).toBe("Sarah Chen");
+    expect(p.communicationStyle).toBe("direct");
+    expect(p.interests).toEqual([]);
+    expect(p.goals).toEqual([]);
+  });
+});

--- a/src/ui/dashboard/utils/resolveChatPersona.ts
+++ b/src/ui/dashboard/utils/resolveChatPersona.ts
@@ -1,0 +1,84 @@
+import type { Persona } from '@/domain/entities/Persona'
+import type { PersonaProfile } from '@/domain/entities/PersonaProfile'
+import type { PersonaResponse } from '@/domain/entities/PersonaResponse'
+import type { PersonaBatch } from '@/ui/stores/personaStore'
+
+/**
+ * Resolve the full Persona behind a simulation response so the report page can
+ * chat in-character. Preference order:
+ *  1. Exact `personaId` match inside the simulation's batch (if known).
+ *  2. Exact `personaId` match across any batch (batch may have been switched).
+ *  3. Name match across any batch (older runs lack personaId).
+ *  4. Reconstruct a persona from the embedded PersonaProfile — degraded but
+ *     usable when the source batch was deleted. Age is unknown → 0, and the
+ *     prompt compiler renders `Age: —` for falsy ages.
+ */
+export function resolveChatPersona(
+  analysis: PersonaResponse,
+  batches: PersonaBatch[],
+): Persona | null {
+  const id = analysis.personaId
+  const name = analysis.personaProfile?.name
+
+  const exactId = (p: Persona) => p.id === id
+  const byName = (p: Persona) => p.name === name
+
+  if (id) {
+    for (const batch of batches) {
+      const found = batch.personas.find(exactId)
+      if (found) return found
+    }
+  }
+
+  if (name) {
+    for (const batch of batches) {
+      const found = batch.personas.find(byName)
+      if (found) return found
+    }
+  }
+
+  return analysis.personaProfile
+    ? personaFromProfile(analysis.personaProfile, id ?? analysis.id)
+    : null
+}
+
+/** Reconstruct a minimal chat-capable Persona from a display projection. */
+export function personaFromProfile(
+  profile: PersonaProfile,
+  id: string,
+): Persona {
+  const {
+    name,
+    occupation,
+    bigFive: {
+      conscientiousness,
+      neuroticism,
+      openness,
+      extraversion,
+      agreeableness,
+    },
+    values,
+    fears,
+    communicationStyle,
+    decisionStyle,
+  } = profile
+
+  return {
+    id,
+    name,
+    age: 0, // unknown — compiler renders "—"
+    occupation,
+    educationLevel: '',
+    interests: [],
+    goals: [],
+    conscientiousness,
+    neuroticism,
+    openness,
+    extraversion,
+    agreeableness,
+    values: [...values],
+    fears: [...fears],
+    communicationStyle,
+    decisionStyle,
+  }
+}

--- a/test/artifact-analysis-detail.spec.ts
+++ b/test/artifact-analysis-detail.spec.ts
@@ -189,8 +189,9 @@ describe('Artifact Analysis Detail — E2E', { timeout: TEST_TIMEOUT }, () => {
     await page.goto(`${BASE_URL}/dashboard/simulations/${SIM_ID}`, { waitUntil: 'networkidle', timeout: TEST_TIMEOUT });
 
     await page.locator('button:has-text("Ask the whole audience")').first().click();
-    expect(await isVisible(page, 'text=Ask your whole audience')).toBe(true);
-    expect(await isVisible(page, 'text=We\'re thinking of adding a free tier — what would you all think?')).toBe(true);
+    expect(await isVisible(page, 'text=Ask the simulated users')).toBe(true);
+    expect(await isVisible(page, 'text=Show me the dissenting opinions.')).toBe(true);
+    expect(await isVisible(page, 'text=Findings describe simulated users — hypotheses to test, not proof about real users.')).toBe(true);
     await page.close();
   });
 

--- a/test/artifact-analysis-detail.spec.ts
+++ b/test/artifact-analysis-detail.spec.ts
@@ -177,6 +177,20 @@ describe('Artifact Analysis Detail — E2E', { timeout: TEST_TIMEOUT }, () => {
     expect(await isVisible(page, 'text=Individual Persona Reports')).toBe(true);
     expect(await isVisible(page, 'text=Sarah Chen')).toBe(true);
     expect(await isVisible(page, 'text=Marcus Lee')).toBe(true);
+
+    // Chat-after-simulation affordances
+    expect(await isVisible(page, 'text=Ask the whole audience')).toBe(true);
+    await page.close();
+  });
+
+  it('opens the panel chat and offers suggested questions', async () => {
+    const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+    await seedSimulationStore(page);
+    await page.goto(`${BASE_URL}/dashboard/simulations/${SIM_ID}`, { waitUntil: 'networkidle', timeout: TEST_TIMEOUT });
+
+    await page.locator('button:has-text("Ask the whole audience")').first().click();
+    expect(await isVisible(page, 'text=Ask your whole audience')).toBe(true);
+    expect(await isVisible(page, 'text=We\'re thinking of adding a free tier — what would you all think?')).toBe(true);
     await page.close();
   });
 
@@ -187,6 +201,7 @@ describe('Artifact Analysis Detail — E2E', { timeout: TEST_TIMEOUT }, () => {
 
     await page.locator('button:has-text("Sarah Chen")').first().click();
     expect(await isVisible(page, 'text=Sarah Chen found the page clear but hesitated on price transparency.')).toBe(true);
+    expect(await isVisible(page, 'text=Ask Sarah Chen about what they saw')).toBe(true);
     await page.close();
   });
 


### PR DESCRIPTION
## Context

The simulation report page had no way to interrogate what the simulated users found. A chat stack existed (PersonaChat → chatWithPersonaAction → ChatWithPersonaUseCase → ChatAdapter) but it was ungrounded: typed against deprecated PricingAnalysis, hardcoded analysis:null, and never surfaced on the report page.

## Changes

- **Per-persona chat on the report page**: each persona card gains "Ask {name} about what they saw", grounding the conversation in that persona's simulation response (overview, journey, findings, frictions, questions, research answer).
- **Panel chat** ("Ask the whole audience"): answers across all personas, with a research-synthesis voice — not a persona, no ID-RAG.
- **Epistemic discipline**: the synthesis prompt enforces a hard simulated-vs-real boundary and a four-layer answer structure (finding → evidence → interpretation → validation) that always names the next test instead of claiming real-user outcomes. Panel chat is framed as "ask the simulated users" with a grounding disclaimer.
- **Markdown rendering** on all chat surfaces (bold, lists, links) via react-markdown + remark-breaks.
- **Streaming scroll fix**: the dependency-less scrollIntoView effect fired on every render, so every streamed token stacked smooth-scroll animations (jitter + call-stack overflow under load). Scroll now fires only when the message list changes, deferred via rAF, instant.

## Tradeoffs

- ChatAnalysisContext is a union (PricingAnalysis | PersonaResponse | null) keeping the deprecated legacy type for backward compat; it should eventually collapse to PersonaResponse alone.
- Profile-derived persona fallback (age 0 → "—") lets chat work even if the source batch is deleted, losing backstory (no ID-RAG) in exchange for resilience.

## Tests

+11 tests (panel/PersonaResponse compiler, chat-with-panel route, resolveChatPersona, markdown renderer); 437 total pass; release gate green.