### PR TITLE
feat(persona): port Aug 6 WIP — English enforcement, persona diversity, journey sentiment

### DIFF
--- a/src/app/(app)/dashboard/simulations/[id]/page.tsx
+++ b/src/app/(app)/dashboard/simulations/[id]/page.tsx
@@ -7,10 +7,11 @@ import { useRouter } from 'next/navigation'
 import { getSimulationResultAction } from '@/actions/getSimulationResult'
 import { getProgressAction } from '@/actions/getProgress'
 import { StepIndicator } from '@/components/custom/StepIndicator'
-import { ArrowLeftIcon, ClockIcon, CheckCircleIcon, XCircleIcon, ThumbsUpIcon, ThumbsDownIcon, AlertTriangleIcon, ChevronDownIcon, ChevronRightIcon, UsersIcon, MessageCircleIcon } from 'lucide-react'
+import { ArrowLeftIcon, ClockIcon, CheckCircleIcon, XCircleIcon, AlertTriangleIcon, ChevronDownIcon, ChevronRightIcon, UsersIcon, MessageCircleIcon } from 'lucide-react'
 import type { Persona } from '@/domain/entities/Persona'
 import type { PersonaResponse } from '@/domain/entities/PersonaResponse'
 import type { MajorFinding } from '@/domain/entities/MajorFinding'
+import type { StageSentiment, StageOutcome } from '@/domain/entities/StageJourney'
 import { computeSynthesis } from '@/ui/dashboard/utils/computeSynthesis'
 import { resolveChatPersona } from '@/ui/dashboard/utils/resolveChatPersona'
 import { PersonaChat } from '@/ui/dashboard/components/chat/PersonaChat'
@@ -27,6 +28,32 @@ function getCurrentStep(step?: string): number {
   if (step === 'INTAKE') return 1
   if (step === 'ANALYZING') return 2
   return 0
+}
+
+// Journey dots encode how the persona FELT at each stage; the outcome badge
+// encodes whether they progressed. Two separate axes — a persona can stop with
+// positive feelings, so color alone would mislead.
+const SENTIMENT_DOT: Record<StageSentiment, string> = {
+  positive: 'bg-green-500',
+  neutral: 'bg-amber-500',
+  negative: 'bg-red-500',
+}
+
+const OUTCOME_META: Record<StageOutcome, { label: string; icon: typeof CheckCircleIcon; className: string }> = {
+  succeeded: { label: 'Passed', icon: CheckCircleIcon, className: 'text-green-600 bg-green-500/10 border-green-500/20' },
+  blocked: { label: 'Blocked', icon: AlertTriangleIcon, className: 'text-amber-600 bg-amber-500/10 border-amber-500/20' },
+  stopped: { label: 'Stopped', icon: XCircleIcon, className: 'text-red-600 bg-red-500/10 border-red-500/20' },
+}
+
+function StageOutcomeBadge({ outcome }: { outcome: StageOutcome }) {
+  const meta = OUTCOME_META[outcome]
+  const Icon = meta.icon
+  return (
+    <span className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-sm text-[10px] font-semibold border ${meta.className}`}>
+      <Icon className="h-2.5 w-2.5" />
+      {meta.label}
+    </span>
+  )
 }
 
 export default function SimulationDetailPage({ params }: { params: Promise<{ id: string }> }) {
@@ -541,9 +568,7 @@ function CompletedView({
                   {analysis.customerJourney && (
                     <div className="flex gap-1">
                       {analysis.customerJourney.map((s) => (
-                        <span key={s.stage} className={`h-2 w-2 rounded-full ${
-                          s.outcome === 'succeeded' ? 'bg-green-500' : s.outcome === 'blocked' ? 'bg-amber-500' : 'bg-red-500'
-                        }`} title={s.stage} />
+                        <span key={s.stage} className={`h-2 w-2 rounded-full ${SENTIMENT_DOT[s.sentiment]}`} title={`${s.stage} — ${s.outcome}`} />
                       ))}
                     </div>
                   )}
@@ -574,18 +599,21 @@ function CompletedView({
                   {analysis.customerJourney?.length > 0 && (
                     <div className="flex flex-col gap-2">
                       <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Journey</p>
+                      <div className="flex items-center gap-3 text-[10px] text-muted-foreground">
+                        <span className="flex items-center gap-1"><span className="h-2 w-2 rounded-full bg-green-500" /> Felt positive</span>
+                        <span className="flex items-center gap-1"><span className="h-2 w-2 rounded-full bg-amber-500" /> Neutral</span>
+                        <span className="flex items-center gap-1"><span className="h-2 w-2 rounded-full bg-red-500" /> Felt negative</span>
+                        <span className="text-muted-foreground/60">· badge = whether they progressed</span>
+                      </div>
                       <div className="flex flex-col gap-1.5">
                         {analysis.customerJourney.map((stage) => (
                           <div key={stage.stage} className="rounded-lg border border-border bg-card/50 p-2.5">
                             <div className="flex items-center gap-2 mb-0.5">
-                              <span className={`h-2 w-2 rounded-full ${
-                                stage.outcome === 'succeeded' ? 'bg-green-500' : stage.outcome === 'blocked' ? 'bg-amber-500' : 'bg-red-500'
-                              }`} />
+                              <span className={`h-2 w-2 rounded-full ${SENTIMENT_DOT[stage.sentiment]}`} />
                               <span className="text-xs font-semibold uppercase tracking-wider">
                                 {stage.stage}
                               </span>
-                              {stage.sentiment === 'positive' && <ThumbsUpIcon className="h-3 w-3 text-green-500" />}
-                              {stage.sentiment === 'negative' && <ThumbsDownIcon className="h-3 w-3 text-red-500" />}
+                              <StageOutcomeBadge outcome={stage.outcome} />
                             </div>
                             <p className="text-xs text-foreground/80">{stage.description}</p>
                           </div>

--- a/src/infrastructure/adapters/PersonaAdapter.ts
+++ b/src/infrastructure/adapters/PersonaAdapter.ts
@@ -1337,6 +1337,12 @@ CRITICAL RULES:
 - If the evidence is thin, say so rather than inventing details.
 - MANDATORY: every persona must include ALL fields in the structure below with non-empty values. A persona missing any field is invalid.
 - Do NOT invent names — names are assigned separately from a curated pool.
+- Write ALL fields in English, even if the source material is in another language.
+
+DIVERSITY REQUIREMENT:
+- Every persona in the array must be a DISTINCT individual. Do NOT produce near-identical personas.
+- All personas share the same evidence pool (the same interviews/audience), but each is a different person within it. Vary across personas: age and career stage, which pain points they emphasize most, priorities, skepticism level, communication style, decision style, and life context.
+- Do not give two personas the same values, fears, or communication style. Two personas may draw on the same interview, but they should weight and interpret that evidence differently.
 
 Generate a JSON array of EXACTLY ${config.count} DISTINCT personas with this structure:
 {
@@ -1583,6 +1589,8 @@ GUIDELINES:
 - Synthetic details are ALLOWED when they help explain behavior.
 - Do NOT add details that would CHANGE product decisions if they were false (counterfactual test).
 - Do NOT invent names — names are assigned separately from a curated pool.
+- Write ALL fields in English, even if the source material is in another language.
+- Every persona must be a DISTINCT individual — do NOT produce near-identical personas. Vary age, career stage, emphasized pain points, values, fears, communication style, and decision style within the shared evidence pool. Do not give two personas the same values, fears, or communication style.
 - MANDATORY: every persona must include ALL fields in the structure below with non-empty values. A persona missing any field is invalid.
 - Every persona MUST include 3-5 behavioralDimensions.
 - evidenceLinks MUST quote the user's response; set attribute to the persona fields the quote supports.

--- a/src/infrastructure/adapters/VisionAnalysisAdapter.ts
+++ b/src/infrastructure/adapters/VisionAnalysisAdapter.ts
@@ -12,6 +12,18 @@ import { streamObject } from "ai";
 import { PricingLocation } from "@/domain/ports/LlmServicePort";
 import { AnalysisLogger } from "@/infrastructure/AnalysisLogger";
 
+// Matches runs of CJK, Hangul, Kana, Cyrillic, Arabic, and Hebrew. Used to
+// catch personas or formatters that drift out of the report language (English).
+const NON_LATIN_RE = /[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uac00-\ud7af\u0600-\u06ff\u0590-\u05ff\u0400-\u04ff]{2,}/g;
+
+function detectNonLatin(text: string): string[] {
+  const found = new Set<string>();
+  for (const m of text.match(NON_LATIN_RE) ?? []) {
+    found.add(m.slice(0, 24));
+  }
+  return [...found];
+}
+
 export class VisionAnalysisAdapter {
     private promptCompiler: PersonaPromptCompiler;
     private ragStore: IdRagStore;
@@ -769,6 +781,8 @@ Convert this into a structured PricingAnalysis JSON object. Return ONLY the JSON
 Each bullet should be one sentence, capturing the most important finding.
 Focus on: what the persona liked, what concerned them, and their overall recommendation.
 
+Write all bullets in English.
+
 Format: Return ONLY a JSON array of strings. No preamble. Example: ["Bullet 1", "Bullet 2", "Bullet 3"]`;
     }
 
@@ -844,8 +858,13 @@ ${ragContextString ? `<<RETRIEVED MEMORY>>\n${ragContextString}\n` : ""}
 
 <<ARTIFACT CONTEXT>>
 You are looking at a user experience — a page, a flow, or a design. You have been provided with:
-1. A screenshot of what the user sees.
-2. A factual summary of the content.
+1. A screenshot of what a user sees on first load.
+2. A factual summary of the page's full content — including content that may be hidden behind interactions you cannot perform (expandable FAQs, dropdowns, menus, modals, pagination).
+
+Treat the summary as the page's full content: if it mentions something not visible in the screenshot, that content exists but is behind an interaction. If you cannot tell whether something is present (for example, whether an FAQ question has an answer), say you couldn't verify it — do not claim it is absent. Only react to details you can actually see or that appear in the summary; do not invent specifics.
+
+<<LANGUAGE>>
+Write everything in English, even if the artifact or the persona's background suggests another language.
 
 <<BUSINESS CONTEXT>>
 The creator of this artifact wants to accomplish: ${businessGoal}
@@ -896,8 +915,13 @@ ${ragContextString ? `<<RETRIEVED MEMORY>>\n${ragContextString}\n` : ""}
 
 <<ARTIFACT CONTEXT>>
 You are looking at a user experience — a page, a flow, or a design. You have been provided with:
-1. A screenshot of what the user sees.
-2. A factual summary of the content.
+1. A screenshot of what a user sees on first load.
+2. A factual summary of the page's full content — including content that may be hidden behind interactions you cannot perform (expandable FAQs, dropdowns, menus, modals, pagination).
+
+Treat the summary as the page's full content: if it mentions something not visible in the screenshot, that content exists but is behind an interaction. If you cannot tell whether something is present (for example, whether an FAQ question has an answer), say you couldn't verify it — do not claim it is absent. Only react to details you can actually see or that appear in the summary; do not invent specifics.
+
+<<LANGUAGE>>
+Write everything in English, even if the artifact or the persona's background suggests another language.
 
 <<BUSINESS CONTEXT>>
 The creator of this artifact wants to accomplish: ${businessGoal}
@@ -954,6 +978,7 @@ CRITICAL RULES — Follow these exactly:
 8. researchQuestionAnswer: describe what evidence was observed from THIS persona only, not what the company should do. Write in first person as the persona.
 9. overview: one paragraph capturing the single most important takeaway from THIS persona's experience.
 10. Do NOT use any persona name (neither this persona's name nor any other persona's name) anywhere in the output. The report is automatically associated with the correct persona by the system.
+11. Write ALL output in English. If the raw reasoning contains another language, translate it to English.
 
 Follow these rules strictly. Findings describe observed behavior, not inferred psychology.`;
     }
@@ -1125,6 +1150,13 @@ Convert this into a structured PersonaResponse JSON object. Return ONLY the JSON
 
         if (!responseObj) {
             throw new Error(`formatPersonaResponse returned null for "${persona.name}"`);
+        }
+
+        const nonLatinFields = detectNonLatin(JSON.stringify(responseObj));
+        if (nonLatinFields.length > 0) {
+            log?.warn("VisionAnalysisAdapter", `Non-English output detected for "${persona.name}"`, {
+                samples: nonLatinFields.slice(0, 3),
+            });
         }
 
         log?.info("VisionAnalysisAdapter", `formatPersonaResponse completed for "${persona.name}"`, {
@@ -1437,6 +1469,7 @@ CRITICAL RULES:
 3. Do NOT assign confidence (computed externally).
 4. Do NOT make recommendations.
 5. Do NOT use persona traits as causal explanations.
+6. Write all output in English.
 
 Return a JSON array of { observation: string, evidence: string, impact: string }`;
 
@@ -1475,6 +1508,7 @@ Your job: Identify where personas had OPPOSING reactions to the same thing. A di
 If most personas agreed on everything, return an empty array.
 
 CRITICAL: Do NOT reference individual persona names. Use group language.
+Write all output in English.
 
 Return a JSON array of { topic: string, split: [{ view: string, personaCount: number }], significance: "High" | "Medium" | "Low" }`;
 
@@ -1508,6 +1542,7 @@ Return a JSON array of { topic: string, split: [{ view: string, personaCount: nu
 Your job: Identify the 2-3 biggest friction points that MULTIPLE personas experienced. A friction point is something that confused, frustrated, or stopped personas.
 
 CRITICAL: Do NOT reference individual persona names. Use group language.
+Write all output in English.
 
 Return a JSON array of strings.`;
 


### PR DESCRIPTION
## Context

Three changes from an uncommitted 2026-08-06 session were found orphaned in the main checkout (never merged, never on dev). This PR ports them onto current dev.

## Changes

- **English enforcement** (PersonaAdapter + VisionAnalysisAdapter): profile prompts require all fields in English even when source material is another language; pricing bullets, PersonaResponse, observations, disagreements, and frictions prompts demand English output; a non-Latin detector warns when non-English text slips through formatted responses.
- **Persona diversity** (PersonaAdapter): research + strategy profile prompts forbid near-identical personas — vary age, career stage, emphasized pain points, values, fears, communication style, decision style within the shared evidence pool.
- **Artifact context honesty** (VisionAnalysisAdapter): prompts now state the screenshot is first-load only while the summary is the full content, so the model doesn't claim hidden content (FAQs, modals, pagination) is absent.
- **Journey sentiment axis** (simulations/[id]): dots encode sentiment (how the persona felt), badges encode outcome (whether they progressed), with a legend — a persona can stop with positive feelings, so color alone misleads.

## What was lost (judgment calls)

- The WIP's second PersonaAdapter hunk targeted `generateResearchPersonasStream`, which dev **retired** in the phased-generation refactor — no literal home. Its intent (English + diversity) was ported to the active research + strategy profile prompts instead.
- The WIP's backstory-level English rule (in the old research prompt) was not separately ported — dev's backstory prompts are per-persona narrative writers and the profile-level English rule covers the fields that surface in the report.

## Tradeoffs

- Prompt additions strengthen the Language and Distinctness verify rubric but add tokens per generation call (negligible — a few lines).
- The non-Latin detector only warns (no hard fail), so it won't block generation — deliberate: catch drift without breaking runs.

## Verification

- tsc clean, full suite 437 tests pass.
- verify-kynd persona run could not complete on **either** this branch or clean dev (pre-existing verbatim/coverage strictness fails on short descriptions) — flagged for user spot-check.